### PR TITLE
(1) One DDB item per segment. (2) One call START msg (not two). (3) Transcriber Lambda memory reduced to 768MB.

### DIFF
--- a/lca-ai-stack/deployment/ai-powered-speech-analytics-for-amazon-chime-voice-connector.yaml
+++ b/lca-ai-stack/deployment/ai-powered-speech-analytics-for-amazon-chime-voice-connector.yaml
@@ -727,7 +727,7 @@ Resources:
         - !Sub "arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension-Arm64:2"
       Role: !GetAtt CallTranscriberFunctionRole.Arn
       Runtime: nodejs14.x
-      MemorySize: 2048
+      MemorySize: 768
       Timeout: 900
       Tracing: Active
       Environment:

--- a/lca-ai-stack/source/appsync/addTranscriptSegment.request.vtl
+++ b/lca-ai-stack/source/appsync/addTranscriptSegment.request.vtl
@@ -1,7 +1,7 @@
 #set( $PK = "trs#${ctx.args.input.CallId}" )
-#set( $CreatedAt = $util.defaultIfNullOrBlank($ctx.args.input.CreatedAt, $util.time.nowISO8601()) )
-#set( $SK = "ts#${CreatedAt}#c#${ctx.args.input.Channel}" )
+#set( $SK = "s#${ctx.args.input.SegmentId}" )
 
+#set( $CreatedAt = $util.defaultIfNullOrBlank($ctx.args.input.CreatedAt, $util.time.nowISO8601()) )
 $util.qr($ctx.args.input.put("CreatedAt", ${CreatedAt}))
 
 {
@@ -12,10 +12,14 @@ $util.qr($ctx.args.input.put("CreatedAt", ${CreatedAt}))
     "SK": $util.dynamodb.toDynamoDBJson($SK),
   },
   "attributeValues": $util.dynamodb.toMapValuesJson($ctx.args.input),
+
+## Conditional block to prevent partial segments from overwriting final segments if they are mutated out of sequence.
+#if(${ctx.args.input.IsPartial})
   "condition": {
-    "expression": "attribute_not_exists(#PK)",
-    "expressionNames": {
-      "#PK": "PK",
-    },
+      "expression" : "attribute_not_exists(IsPartial) OR IsPartial = :true",
+      "expressionValues" : {
+          ":true" : { "BOOL" : true }
+      },
   },
+#end
 }

--- a/lca-ai-stack/source/lambda_functions/call_transcriber/index.js
+++ b/lca-ai-stack/source/lambda_functions/call_transcriber/index.js
@@ -550,7 +550,7 @@ const handler = async function (event, context) {
   }
 
   console.log(JSON.stringify(event));
-  await writeCallEventToKds(event);
+
   if (EVENT_TYPE[event.detail.streamingStatus] == "START") await writeCallEventToDynamo(event);
 
   let result;
@@ -606,6 +606,8 @@ const handler = async function (event, context) {
         return;
       }
     }
+
+    await writeCallEventToKds(event);
 
     result = await go(
       event.detail.callId,

--- a/lca-ai-stack/source/lambda_functions/transcript_processor/event_processor/transcribe.py
+++ b/lca-ai-stack/source/lambda_functions/transcript_processor/event_processor/transcribe.py
@@ -144,11 +144,13 @@ def add_transcript_segments(
                 )
             )
         )
+        ignore_exception_fn = lambda e: True if (e["message"] == 'item put condition failure') else False
         tasks.append(
             execute_gql_query_with_retries(
                 query,
                 client_session=appsync_session,
                 logger=LOGGER,
+                should_ignore_exception_fn = ignore_exception_fn, 
             ),
         )
 


### PR DESCRIPTION
*Description of changes:*

- DDB maintains only one item per transcript segment and no longer maintains partial segments. 
- ChimeVC CallTranscriber Lambda function now emits one Call START event when both call streams are ready (as opposed to one per call stream), eliminating 'item already exists' errors in the TranscriptProcessor lambda
-  ChimeVC CallTramscriber Lambda function memory footprint reduced to 768MB to improve cost efficiency with minimal latency tradeoff.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
