### PR TITLE
fix: install dependencies for call transcriber lambda

### DIFF
--- a/lca-chimevc-stack/publish.sh
+++ b/lca-chimevc-stack/publish.sh
@@ -41,6 +41,12 @@ else
   PUBLIC=false
 fi
 
+transcriber_dir=lambda_functions/call_transcriber
+echo "Installing dependencies for $transcriber_dir"
+pushd $transcriber_dir
+npm install
+popd
+
 # Create bucket if it doesn't already exist
 aws s3api list-buckets --query 'Buckets[].Name' | grep "\"$BUCKET\"" > /dev/null 2>&1
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
*Issue #, if available:* 

call transcriber did not deploy dependencies

*Description of changes:*

updated publish.sh for chime vc stack to call npm install on the call transcriber folder

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
