### PR TITLE
Fix/limit stackname length. Provide 'reason' message for stack custom resource failures. Expand Troubleshooting README.

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,15 +1,39 @@
 # Troubleshooting
 
-### If the CloudFormation stack deployment fails, and you are deploying with the Demo Asterisk Server:
+If the CloudFormation stack deployment fails, use the Events tab to find the first CREATE_FAILED message.
+  
+If the CREATE_FAILED message refers to a nested stack, then find that nested stack, and anad navigate to the first CREATE_FAILED message. NOTE - if your stack rolled back already, the nested stacks are automatically deleted for you, so to find them change the Stacks filter from `Active` to `Deleted`. 
+  
+Stacks may be nested several levels deep, so keep drilling down till you find the first resource that failed in the more deeply nested stack.
+  
+Examine the Status reason column for clues to the failure reason.
+  
+Some common failure reasons are listed below.
 
-1. In the AWS Management Console, navigate to the CloudWatch service, then CloudWatch Logs.
-2. Search for a log group that contains your stack name, appended with CHIMEVCSTACK, for example, */aws/lambda/LiveCallAnalytics-CHIMEVCSTACK-XXXX-createLambdaVC-XXXXXXXXXXXX*, and click it.
-3. Click the log stream to view its contents.
-4. Search for the word *error* in the search bar.
-5. If you find an error, and the error message says: *Exception thrown: An error occurred (AccessDeniedException) when calling the SearchAvailablePhoneNumbers operation: Service is restricted for AWSAccountId XXXXXXXXXXXX*
-   1. Navigate to the Amazon Chime console
-   2. In the upper right, select *Support* > *Submit Request*
-   3. For Category, choose *Voice Calling*
-   4. For Subject, enter *Unable to search for phone numbers with LCA*
-   5. For Issue, enter *I am deploying the AWS Live Call Analytics Solution, and I am receiving this error: Exception thrown: An error occurred (AccessDeniedException) when calling the SearchAvailablePhoneNumbers operation: Service is restricted for AWSAccountId XXXXXXXXXXXX*
-6. If you are still having issues, please open an AWS Support Case by navigating to the Support Center in the AWS Management Console, and click on "Create Case". 
+- *An error occurred (AccessDeniedException) when calling the SearchAvailablePhoneNumbers operation: Service is restricted for AWSAccountId XXXXXXXXXXXX* 
+  - Cause: Your CallAudioSource is *Demo Asterisk PBX Server* and your AWS account has not (yet) been granted permission to allocate a Phone Number. 
+  - Suggested Actions:
+      1. Navigate to the Amazon Chime console
+      2. In the upper right, select *Support* > *Submit Request*
+      3. For Category, choose *Voice Calling*
+      4. For Subject, enter *Unable to search for phone numbers with LCA*
+      5. For Issue, enter *I am deploying the AWS Live Call Analytics Solution, and I am receiving this error: Exception thrown: An error occurred (AccessDeniedException) when calling the SearchAvailablePhoneNumbers operation: Service is restricted for AWSAccountId XXXXXXXXXXXX*
+      6. If you are still having issues, please open an AWS Support Case by navigating to the Support Center in the AWS Management Console, and click on "Create Case". 
+  
+    
+- *An error occurred (BadRequestException) when calling the CreateVoiceConnector operation: Service received a bad request.*
+  - Cause: Your CallAudioSource is *Demo Asterisk PBX Server* or *Chime VC SIPREC* your AWS account already has 3 (max) Voice Connectors. 
+  - Suggested Actions:
+      1. Navigate to the Amazon Chime console
+      2. Choose **Voice Connectors**
+      3. Check if there are already 3 existing Voice Connectors. If so, you have reached the maximum number of voice connectors. In order to create a new voice connector, you will need to delete an existing voice connector.
+      4. If you have already 3 LCA stacks installed, remove one or more of them to also remove the associated voice connector. Otherwise delete unused Voice Connectors from the Chime console: see [Deleting an Amazon Chime Voice Connector](https://docs.aws.amazon.com/chime-sdk/latest/ag/delete-voicecon.html)
+   
+     
+- *You have attempted to create more buckets than allowed*
+  - Cause: Your account has reached the maximum allowed limit for number of S3 buckets (default 100) 
+  - Suggested Actions:
+      1. Empty and Delete unused buckets. Delete unused Cloudformation stacks that may have created buckets. OR
+      2. Request a limit increase for number of Buckets at [ServiceQuotas](https://us-east-1.console.aws.amazon.com/servicequotas/home/services/s3/quotas)
+
+

--- a/lca-agentassist-setup-stack/template.yaml
+++ b/lca-agentassist-setup-stack/template.yaml
@@ -333,6 +333,7 @@ Resources:
           def handler(event, context):
             print(json.dumps(event))
             status = cfnresponse.SUCCESS
+            reason = "Success"
             responseData = {}
             responseData['Data'] = "Success"
             if event['RequestType'] != 'Delete':
@@ -344,9 +345,9 @@ Resources:
                   setupQnABot(props, oldprops)
               except Exception as e:
                 print(e)
-                responseData["Error"] = f"Exception thrown: {e}"
+                reason = f"Exception thrown: {e}"
                 status = cfnresponse.FAILED
-            cfnresponse.send(event, context, status, responseData)
+            cfnresponse.send(event, context, status, responseData, reason=reason)
 
   # Trigger Lambda function
   SetupFunctionResource:

--- a/lca-ai-stack/deployment/lca-ai-stack.yaml
+++ b/lca-ai-stack/deployment/lca-ai-stack.yaml
@@ -1262,15 +1262,15 @@ Resources:
             print(event)
             responseData = {}
             status = cfnresponse.SUCCESS
+            reason = "Success"
             if event['RequestType'] == 'Delete':
               try:
                 deleteS3Bucket(event['ResourceProperties']['BucketName'])
               except Exception as e:
                 print(e)
-                responseData["Error"] = f"Exception thrown: {e}"
+                reason = f"Exception thrown: {e}"
                 status = cfnresponse.FAILED
-                responseData['Data'] = "Success"
-            cfnresponse.send(event, context, status, responseData)
+            cfnresponse.send(event, context, status, responseData, reason=reason)
 
   RemoveWebAppBucketOnDelete:
     Type: Custom::RemoveWebAppBucketOnDelete

--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-siprec.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-siprec.yaml
@@ -138,18 +138,18 @@ Resources:
                 responseData = create_vc(event)
                 cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)                
               except Exception as e:
-                error = { 'error': f'Exception thrown: {e}'}
+                error = f'Exception thrown: {e}. Please see https://github.com/aws-samples/amazon-transcribe-live-call-analytics/blob/main/TROUBLESHOOTING.md for more information.'
                 print(error)
-                cfnresponse.send(event, context, cfnresponse.FAILED, error )   
+                cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=error )   
             elif event['RequestType'] == 'Delete':
               try:
                 delete_vc(event)
                 responseData = {'Message': 'Deleting VC.  Returning success status.'}                   
                 cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)                      
               except Exception as e:
-                error = { 'error': f'Exception thrown: {e}'}
+                error = f'Exception thrown: {e}. Please see https://github.com/aws-samples/amazon-transcribe-live-call-analytics/blob/main/TROUBLESHOOTING.md for more information.'
                 print(error)
-                cfnresponse.send(event, context, cfnresponse.FAILED, error )   
+                cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=error )   
             else:
                 responseData = {'Message': 'Update is no-op. Returning success status.'}
                 cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)

--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-with-asterisk-server.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-with-asterisk-server.yaml
@@ -499,9 +499,9 @@ Resources:
                     authorizeEIP(voiceConnector['voiceConnectorId'], elasticIP)
                     cfnresponse.send(event, context, cfnresponse.SUCCESS, voiceConnector, physical_id)
                   except Exception as e:
-                    error = { 'Error': f'Exception thrown: {e}. Please see https://github.com/aws-samples/amazon-transcribe-live-call-analytics/blob/main/TROUBLESHOOTING.md for more information.'}
+                    error = f'Exception thrown: {e}. Please see https://github.com/aws-samples/amazon-transcribe-live-call-analytics/blob/main/TROUBLESHOOTING.md for more information.'
                     print(error)
-                    cfnresponse.send(event, context, cfnresponse.FAILED, error )                    
+                    cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=error )                    
               elif event['RequestType'] == 'Delete':
                   try:              
                     physical_id = 'VoiceConnectorResources'
@@ -530,9 +530,9 @@ Resources:
                       responseData = {'Message': 'No Cloudformation Output. Returning success status.'}
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)                      
                   except Exception as e:
-                    error = { 'Error': f'Exception thrown: {e}. Please see https://github.com/aws-samples/amazon-transcribe-live-call-analytics/blob/main/TROUBLESHOOTING.md for more information.'}
+                    error = f'Exception thrown: {e}. Please see https://github.com/aws-samples/amazon-transcribe-live-call-analytics/blob/main/TROUBLESHOOTING.md for more information.'
                     print(error)
-                    cfnresponse.send(event, context, cfnresponse.FAILED, error )                      
+                    cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=error )                      
               else:
                   responseData = {'Message': 'Update is no-op. Returning success status.'}
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)

--- a/lca-connect-integration-stack/template.yaml
+++ b/lca-connect-integration-stack/template.yaml
@@ -137,7 +137,7 @@ Resources:
             print(json.dumps(event))
             status = cfnresponse.SUCCESS
             responseData = {}
-            responseData['Data'] = "Success"
+            reason = "Success"
             props = event["ResourceProperties"]
             if event['RequestType'] != 'Delete':
               try:
@@ -145,9 +145,9 @@ Resources:
                 associateConnectInstance(props)
               except Exception as e:
                 print(e)
-                responseData["Error"] = f"Exception thrown: {e}"
+                reason = f"Exception thrown: {e}"
                 status = cfnresponse.FAILED              
-            cfnresponse.send(event, context, status, responseData)
+            cfnresponse.send(event, context, status, responseData, reason=reason)
 
   # Trigger Lambda function
   AssociateInstanceFunctionResource:

--- a/lca-genesys-audiohook-stack/deployment/genesys-audiohook.yaml
+++ b/lca-genesys-audiohook-stack/deployment/genesys-audiohook.yaml
@@ -263,6 +263,7 @@ Resources:
               print(event)
               status = cfnresponse.SUCCESS
               response_data = {}
+              reason = "Success"
               if event["RequestType"] == "Delete":
                   try:
                       repository_name = event["ResourceProperties"]["RepositoryName"]
@@ -270,9 +271,9 @@ Resources:
                       response_data["RepositoryName"] = repository_name
                   except Exception as e:
                       print(e)
-                      response_data["Reason"] = f"Exception thrown: {e}"
+                      reason = f"Exception thrown: {e}"
                       status = cfnresponse.FAILED
-              cfnresponse.send(event, context, status, response_data)
+              cfnresponse.send(event, context, status, response_data, reason=reason)
 
   EcrImagesDelete:
     Type: Custom::EcrImagesDelete

--- a/lca-main.yaml
+++ b/lca-main.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 ---
 AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
 
 Description: Amazon Transcribe Live Call Analytics with Agent Assist - LCA (v0.5.0)
 
@@ -447,9 +448,41 @@ Rules:
 
 Resources:
 
+  # Custom resource to enforce max length of StackName - prevent downstream failures                                             
+  StacknameCheckFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: python3.8
+      InlineCode: |
+          import cfnresponse
+          import time
+          import json
+          def handler(event, context):
+              print(json.dumps(event))
+              input = event['ResourceProperties'].get('InputString', '')
+              max_length = int(event['ResourceProperties'].get('MaxLength', 0))
+              status = cfnresponse.SUCCESS
+              reason = f"Stack Name Length under {max_length} - OK"
+              if event['RequestType'] == "Create":
+                if len(input) > max_length:
+                  status = cfnresponse.FAILED
+                  reason = f"Stack Name length too long - max length {max_length} - FAILED"
+              else:
+                print(f"Request type is {event['RequestType']} - skipping")
+              cfnresponse.send(event, context, status, {}, reason=reason) 
+
+  IsStacknameLengthOK:
+    Type: Custom::StacknameCheck
+    Properties:
+      ServiceToken: !GetAtt StacknameCheckFunction.Arn
+      InputString: !Ref 'AWS::StackName'
+      MaxLength: 25
+
   KENDRA:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldCreateKendraIndex
+    DependsOn: IsStacknameLengthOK
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-kendra-stack/template.yaml
@@ -464,6 +497,7 @@ Resources:
   QNABOT:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldInstallAWSQnaBot
+    DependsOn: IsStacknameLengthOK
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/aws-qnabot/templates/master.json
@@ -483,6 +517,7 @@ Resources:
 
   AISTACK:
     Type: AWS::CloudFormation::Stack
+    DependsOn: IsStacknameLengthOK
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-ai-stack/<VERSION_TOKEN>/template.yaml

--- a/publish.sh
+++ b/publish.sh
@@ -153,8 +153,8 @@ fi
 
 echo "OUTPUTS"
 echo Template URL: $template
-echo CF Launch URL: https://${REGION}.console.aws.amazon.com/cloudformation/home?region=${REGION}#/stacks/create/review?templateURL=${template}\&stackName=LiveCallAnalytics
-echo CLI Deploy: aws cloudformation deploy --region $REGION --template-file $tmpdir/$MAIN_TEMPLATE --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --stack-name LiveCallAnalytics --parameter-overrides AdminEmail='jdoe@example.com' CallAudioSource='Demo Asterisk PBX Server' demoSoftphoneAllowedCidr=CIDRBLOCK siprecAllowedCidrList=\"\" S3BucketName=\"\"
+echo CF Launch URL: https://${REGION}.console.aws.amazon.com/cloudformation/home?region=${REGION}#/stacks/create/review?templateURL=${template}\&stackName=LCA
+echo CLI Deploy: aws cloudformation deploy --region $REGION --template-file $tmpdir/$MAIN_TEMPLATE --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND --stack-name LCA --parameter-overrides AdminEmail='jdoe@example.com' CallAudioSource='Demo Asterisk PBX Server' demoSoftphoneAllowedCidr=CIDRBLOCK siprecAllowedCidrList=\"\" S3BucketName=\"\"
 echo Done
 exit 0
 


### PR DESCRIPTION
*Description of changes:*

- Check StackName length and fail fast if length would cause downstream staack failures caused by long resource names in nested stacks. Max Stack Name is now 25 characters.
- Provide 'reason' message for stack custom resource failures. 
- Expand Troubleshooting README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
