### PR TITLE
Use QnABot markdown response when available

### DIFF
--- a/lca-ai-stack/source/lambda_functions/call_event_processor/event_processor/contact_lens.py
+++ b/lca-ai-stack/source/lambda_functions/call_event_processor/event_processor/contact_lens.py
@@ -491,7 +491,15 @@ def get_lex_agent_assist_message(bot_response):
         # ignore 'noanswer' responses from QnABot
         LOGGER.debug("QnABot \"Dont't know\" response - ignoring")
         return ""
-    if "messages" in bot_response and bot_response["messages"]:
+    # Use markdown if present in appContext.altMessages.markdown session attr (Lex Web UI / QnABot)
+    appContextJSON = bot_response.get("sessionState",{}).get("sessionAttributes",{}).get("appContext")
+    if appContextJSON:
+        appContext = json.loads(appContextJSON)
+        markdown = appContext.get("altMessages",{}).get("markdown")
+        if markdown:
+            message = markdown
+    # otherwise use bot message
+    if not message and "messages" in bot_response and bot_response["messages"]:
         message = bot_response["messages"][0]["content"]
     return message
 

--- a/lca-ai-stack/source/lambda_functions/call_event_processor/event_processor/transcribe.py
+++ b/lca-ai-stack/source/lambda_functions/call_event_processor/event_processor/transcribe.py
@@ -400,7 +400,15 @@ def get_lex_agent_assist_message(bot_response):
         # ignore 'noanswer' responses from QnABot
         LOGGER.debug("QnABot \"Dont't know\" response - ignoring")
         return ""
-    if "messages" in bot_response and bot_response["messages"]:
+    # Use markdown if present in appContext.altMessages.markdown session attr (Lex Web UI / QnABot)
+    appContextJSON = bot_response.get("sessionState",{}).get("sessionAttributes",{}).get("appContext")
+    if appContextJSON:
+        appContext = json.loads(appContextJSON)
+        markdown = appContext.get("altMessages",{}).get("markdown")
+        if markdown:
+            message = markdown
+    # otherwise use bot message
+    if not message and "messages" in bot_response and bot_response["messages"]:
         message = bot_response["messages"][0]["content"]
     return message
 


### PR DESCRIPTION
*Description of changes:*

Use QnABot markdown response when available, to take advantage of new markdown rendering feature for Agent Assist.
![image](https://user-images.githubusercontent.com/10953374/193161145-90e21265-15f7-446f-8e25-9d48972acc93.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
