### PR TITLE
Feature/add call metadatajson

### DIFF
--- a/lca-ai-stack/source/appsync/schema.graphql
+++ b/lca-ai-stack/source/appsync/schema.graphql
@@ -29,6 +29,7 @@ type Call implements DynamoDbBase @aws_cognito_user_pools
 	RecordingUrl: String
 	TotalConversationDurationMillis: Float
 	AgentId: String
+	Metadatajson: String
 }
 
 type CallList @aws_cognito_user_pools
@@ -65,6 +66,7 @@ input CreateCallInput {
 	AgentId: String
 	CustomerPhoneNumber: String
 	SystemPhoneNumber: String
+	Metadatajson: String
 	ExpiresAfter: AWSTimestamp
 }
 

--- a/lca-chimevc-stack/LambdaHookFunction.md
+++ b/lca-chimevc-stack/LambdaHookFunction.md
@@ -12,6 +12,7 @@ LCA v0.5.0 and later offers optional custom logic via a user-provided Lambda fun
 5. Override the default toNumber (System Phone number)
 6. Override the default fromNumber (Caller Phone number)
 7. Selectively choose whether to save call recording to S3
+8. Attach optional arbitrary metadata json object to call record, for use by downstream custom applications via the LCA graphQL API or DynamoDB event sourcing table. NOTE metadatajson values are not currently used by the LCA UI.
 
 To use this feature:
 1. Implement a Lambda function with the desired business logic
@@ -31,7 +32,8 @@ Your Lambda implements your required business logic, and returns a simple JSON s
             agentId: <string>,
             fromNumber: <string>,
             toNumber: <string>,
-            shouldRecordCall: <boolean>
+            shouldRecordCall: <boolean>,
+            metadatajson: <string>
           }
 ``` 
 Here is a minimal example of a valid custom Lambda hook function, written in node.js
@@ -47,6 +49,7 @@ exports.handler = async (event) => {
             fromNumber: "Bob's cell",
             toNumber: "Demo Asterisk",
             shouldRecordCall: false,
+            metadatajson: JSON.stringify({key1:"value1", key2:"value2"}),
           }
     return response;
 };
@@ -59,6 +62,7 @@ This minimal function:
 - replaces the `fromNumber` value with a (hardcoded) string
 - replaces the `toNumber` value with a (hardcoded) string
 - disables call audio recording
+- adds metadata to the call, as an arbitrary JSON string - metadata is written 
 
 Your function will be much smarter, possibly interacting with your IVR or CRM to determine the desired behavior.
 
@@ -68,14 +72,14 @@ If your function provides a valid response, the LCA ChimeVC CallTranscriber proc
 ```
 INFO Invoking LambdaHook: arn:aws:lambda:us-east-1:XXXXXXXXXXXX:function:testLambdaHook
 INFO LambdaHook response: {"originalCallId":"cfaafd64-0eed-4fdd-9699-321b6ce14d54","shouldProcessCall":true,"isCaller":false,"callId":...
-INFO Lambda hook returned shouldProcessCall=true, continuing.
 INFO Lambda hook returned new callId: "MODIFIED-cfaafd64-0eed-4fdd-9699-321b6ce14d54"
 INFO Lambda hook returned isCaller=false, swapping caller/agent streams
 INFO Lambda hook returned agentId: "Bob the Builder"
 INFO Lambda hook returned fromNumber: "Bob's cell"
 INFO Lambda hook returned toNumber: "Demo Asterisk"
+INFO Lambda hook returned metadatajson: "{"key1":"value1","key2":"value2"}"
+INFO Lambda hook returned shouldProcessCall=true, continuing.
 INFO Lambda hook returned shouldRecordCall=false, audio recording disabled.
-
 ```
 
 If your function response sets `shouldProcessCall` to `false` the CallTranscriber function logs a message and exits without processing the call. No other response fields matter in this case.

--- a/lca-chimevc-stack/LambdaHookFunction.md
+++ b/lca-chimevc-stack/LambdaHookFunction.md
@@ -11,6 +11,7 @@ LCA v0.5.0 and later offers optional custom logic via a user-provided Lambda fun
 4. Override the default CallId with another unique value for the call
 5. Override the default toNumber (System Phone number)
 6. Override the default fromNumber (Caller Phone number)
+7. Selectively choose whether to save call recording to S3
 
 To use this feature:
 1. Implement a Lambda function with the desired business logic
@@ -29,7 +30,8 @@ Your Lambda implements your required business logic, and returns a simple JSON s
             callId: <string>,
             agentId: <string>,
             fromNumber: <string>,
-            toNumber: <string>
+            toNumber: <string>,
+            shouldRecordCall: <boolean>
           }
 ``` 
 Here is a minimal example of a valid custom Lambda hook function, written in node.js
@@ -43,7 +45,8 @@ exports.handler = async (event) => {
             callId: `MODIFIED-${event.detail.callId}`,
             agentId: "Bob the Builder",
             fromNumber: "Bob's cell",
-            toNumber: "Demo Asterisk"
+            toNumber: "Demo Asterisk",
+            shouldRecordCall: false,
           }
     return response;
 };
@@ -55,6 +58,7 @@ This minimal function:
 - assigns a (hardcoded) agentId to the call
 - replaces the `fromNumber` value with a (hardcoded) string
 - replaces the `toNumber` value with a (hardcoded) string
+- disables call audio recording
 
 Your function will be much smarter, possibly interacting with your IVR or CRM to determine the desired behavior.
 
@@ -70,6 +74,8 @@ INFO Lambda hook returned isCaller=false, swapping caller/agent streams
 INFO Lambda hook returned agentId: "Bob the Builder"
 INFO Lambda hook returned fromNumber: "Bob's cell"
 INFO Lambda hook returned toNumber: "Demo Asterisk"
+INFO Lambda hook returned shouldRecordCall=false, audio recording disabled.
+
 ```
 
 If your function response sets `shouldProcessCall` to `false` the CallTranscriber function logs a message and exits without processing the call. No other response fields matter in this case.

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -186,6 +186,7 @@ const writeCallStartEventToKds = async function (callData) {
     CustomerPhoneNumber: callData.fromNumber,
     SystemPhoneNumber: callData.toNumber,
     AgentId: callData.agentId,
+    Metadatajson: callData.metadatajson,
     EventType: "START",
   };
   const putParams = {
@@ -245,6 +246,7 @@ const getCallDataFromChimeEvents = async function (callEvent) {
     fromNumber: callEvent.detail.fromNumber,
     toNumber: callEvent.detail.toNumber,
     agentId: callEvent.detail.agentId,
+    metadatajson: undefined,
     callerStreamArn: callerStreamArn,
     agentStreamArn: agentStreamArn,
     lambdaCount: 0,
@@ -278,6 +280,7 @@ const getCallDataFromChimeEvents = async function (callEvent) {
           fromNumber: <string>,
           toNumber: <string>,
           shouldRecordCall: <boolean>,
+          metadatajson: <string>
         }
     */
 
@@ -310,6 +313,12 @@ const getCallDataFromChimeEvents = async function (callEvent) {
     if (payload.toNumber) {
       console.log(`Lambda hook returned toNumber: "${payload.toNumber}"`);
       callData.toNumber = payload.toNumber;
+    }
+
+    // Metadata?
+    if (payload.metadatajson) {
+      console.log(`Lambda hook returned metadatajson: "${payload.metadatajson}"`);
+      callData.metadatajson = payload.metadatajson;
     }
 
     // Should we process this call?


### PR DESCRIPTION
*Description of changes:*

ChimeVC call initialization Lambda hook can now assign arbitrary call metadata using 'callmetadatajson' field. 
KDS START record provides metadatajson (if defined) to call event processor. 
Metadatajson field added to AppSync schema, and is now included (if defined) in call record mutation and stored by AppSync in c# records in the event sourcing DynamoDB table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
