### PR TITLE
Feature/add transcript processor lambda hook

### DIFF
--- a/lca-agentassist-setup-stack/template.yaml
+++ b/lca-agentassist-setup-stack/template.yaml
@@ -66,7 +66,29 @@ Parameters:
     Type: String
     Default: https://en.wikipedia.org/wiki/Life_insurance, https://en.wikipedia.org/wiki/Mortgage_loan
     Description: >-
-      Comma separated list of public web sites to crawl automatically - for Agent assist demo 
+      Comma separated list of public web sites to crawl automatically - for Agent assist demo
+
+  # Changes to Params below force AgentAssist Setup to update.
+  AgentAssistOption:
+    Type: String
+  AgentAssistExistingKendraIndexId:
+    Type: String
+  AgentAssistExistingLexV2BotId:
+    Type: String
+  AgentAssistExistingLexV2BotAliasId:
+    Type: String
+  AgentAssistExistingLambdaFunctionArn:
+    Type: String
+  TranscribeLanguageCode:
+    Type: String
+  IsSentimentAnalysisEnabled:
+    Type: String
+  TranscriptLambdaHookFunctionArn:
+    Type: String
+  TranscriptLambdaHookFunctionNonPartialOnly:
+    Type: String
+  DynamoDbExpirationInDays:
+    Type: String
 
 Conditions:
   ShouldConfigureQnabot: !Not [!Equals [!Ref QNABOTSTACK, '']]
@@ -361,6 +383,17 @@ Resources:
       KendraIndexId: !Ref KendraIndexId
       QnaAgentAssistDemoJson: !Ref QnaAgentAssistDemoJson
       QnaAgentAssistDemoWebCrawlURLs: !Ref QnaAgentAssistDemoWebCrawlURLs
+      # Changes to Params below force AgentAssist Setup to execute.
+      AgentAssistOption: !Ref AgentAssistOption
+      AgentAssistExistingKendraIndexId: !Ref AgentAssistExistingKendraIndexId
+      AgentAssistExistingLexV2BotId: !Ref AgentAssistExistingLexV2BotId
+      AgentAssistExistingLexV2BotAliasId: !Ref AgentAssistExistingLexV2BotAliasId
+      AgentAssistExistingLambdaFunctionArn: !Ref AgentAssistExistingLambdaFunctionArn
+      TranscribeLanguageCode: !Ref TranscribeLanguageCode
+      IsSentimentAnalysisEnabled: !Ref IsSentimentAnalysisEnabled
+      TranscriptLambdaHookFunctionArn: !Ref TranscriptLambdaHookFunctionArn
+      TranscriptLambdaHookFunctionNonPartialOnly: !Ref TranscriptLambdaHookFunctionNonPartialOnly
+      DynamoDbExpirationInDays: !Ref DynamoDbExpirationInDays
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
 

--- a/lca-ai-stack/TranscriptLambdaHookFunction.md
+++ b/lca-ai-stack/TranscriptLambdaHookFunction.md
@@ -1,0 +1,101 @@
+# Using a Lambda function to optionally provide custom logic for transcript processing
+
+## Overview
+
+LCA v0.5.2 and later offers optional custom logic via a user-provided Lambda function, to support the following features:
+1. Modify Transcriptions in real time using custom logic, for example, implement your redaction or profanity filtering rules.
+2. Choose to process non-partial (final) transcript segments only, or both partial (not final) and non-partial (final) transcript segments.
+3. Log or save transcript segments to an external data store.
+
+To use this feature:
+1. Implement a Lambda function with the desired business logic.
+2. Use CloudFormation to register the Lambda with your LCA stack - **Lambda Hook Function ARN for Custom Transcript Segment Processing (existing)**.
+3. Use CloudFormation to choose whether to call your function for NonPartial segments only, or all segments - **Lambda Hook Function Mode Non-Partial only**.
+
+
+## Transcript Lambda function requirements
+
+Your Lambda function will be invoked by the LCA AISTACK CallEventProcessor function for each transcription message read from the incoming KDS stream. The message passed as the input event to your Lambda looks like this:
+
+```
+{
+    "Transcript": "My personal identifier is ABCDEF.",
+    "Channel": "CALLER",
+    "TransactionId": "634b0a5d-2f8e-482f-bde3-d3275355c500",
+    "CallId": "888660e1-70a6-410e-a765-1d20517db270",
+    "SegmentId": "a71ca594-0a75-4506-9713-7dafaf3f9326",
+    "StartTime": "27.42",
+    "EndTime": "30.955",
+    "IsPartial": false,
+    "EventType": "ADD_TRANSCRIPT_SEGMENT",
+    "CreatedAt": "2022-10-18T21:51:23.172Z",
+    "ExpiresAfter": 1671313884
+}
+```
+
+Your Lambda implements the required business logic, and returns the same event structure with fields optionally modified. The example below shows
+the "Transcript" field modified to redact the personal identifier using custom business logic.
+```
+{
+    "Transcript": "My personal identifier is [PIN].",
+    "Channel": "CALLER",
+    "TransactionId": "634b0a5d-2f8e-482f-bde3-d3275355c500",
+    "CallId": "888660e1-70a6-410e-a765-1d20517db270",
+    "SegmentId": "a71ca594-0a75-4506-9713-7dafaf3f9326",
+    "StartTime": "27.42",
+    "EndTime": "30.955",
+    "IsPartial": false,
+    "EventType": "ADD_TRANSCRIPT_SEGMENT",
+    "CreatedAt": "2022-10-18T21:51:23.172Z",
+    "ExpiresAfter": 1671313884
+}
+``` 
+
+The modified value of "Transcript" is subsequently displayed in the LCA UI, and stored in the LCA DynamoDB event sourcing table.   
+  
+The modified version is also used by default as input to the Agent Assist Lex bot or Lambda function, if Agent Assist is enabled. To use the original, unmodified transcript for Agent Assist, your function must add an additional field, `OriginalTranscript`, to the returned message. When the returned messsage contains the `OriginalTranscript` field, this value is used as input to Agent Assist. Example:
+
+```
+{
+    "OriginalTranscript": "My personal identifier is ABCDEF.",
+    "Transcript": "My personal identifier is [PIN].",
+    "Channel": "CALLER",
+    "TransactionId": "634b0a5d-2f8e-482f-bde3-d3275355c500",
+    "CallId": "888660e1-70a6-410e-a765-1d20517db270",
+    "SegmentId": "a71ca594-0a75-4506-9713-7dafaf3f9326",
+    "StartTime": "27.42",
+    "EndTime": "30.955",
+    "IsPartial": false,
+    "EventType": "ADD_TRANSCRIPT_SEGMENT",
+    "CreatedAt": "2022-10-18T21:51:23.172Z",
+    "ExpiresAfter": 1671313884
+}
+``` 
+
+Here is a minimal example of a valid custom Transcript Lambda hook function, written in Python. 
+```
+import json
+
+def lambda_handler(event, context):
+    print(json.dumps(event))
+    event["OriginalTranscript"] = event["Transcript"]
+    event["Transcript"] = event["Transcript"].upper()
+    print(json.dumps(event))
+    return event
+``` 
+
+This example function trivially converts the transcript to uppercase while preserving the original for use with agent assist. Your function will be much smarter, and will implement your custom rules or models.
+
+The CallEventProcessor function calls your Lambda syncronously, waiting for a valid response. If your Lambda fails or times out before completing, the CallEventProcessor Lambda throws an exception and drops the transcript. Be sure to test your function properly using test events, and log messages so you can check that it fucntions as expected.  
+Your function is invoked for every non-partial transcript segment (by default), or for every partial and non-partial segment (by setting **Lambda Hook Function Mode Non-Partial only** to *false*). Make your function as lightweight and fast as possible to minimize latency and cost. 
+
+
+## Register the Lambda function with LCA
+
+Use the LCA CloudFormation template parameter **Lambda Hook Function ARN for Custom Transcript Segment Processing (existing)** to set the ARN value for your custom Lambda hook function when ceating a new LCA stack, or when updating an existing one. You find the ARN for your Lambda in the AWS Lambda console - it has this format:
+```
+arn:aws:lambda:us-east-1:<accountId>:function:<functionName>
+```
+
+Use the LCA CloudFormation template parameter **Lambda Hook Function Mode Non-Partial only** to choose whether to call your function for NonPartial segments only (`true`, recommended) , or all segments (`false`).
+

--- a/lca-ai-stack/deployment/lca-ai-stack.yaml
+++ b/lca-ai-stack/deployment/lca-ai-stack.yaml
@@ -70,6 +70,25 @@ Parameters:
       - zh
       # - zh-TW
 
+  TranscriptLambdaHookFunctionArn:
+    Default: ''
+    Type: String
+    AllowedPattern: '^(|arn:aws:lambda:.*)$'
+    Description: >
+      (Optional) If present, the specified Lambda function is invoked by the LCA Call Event Processor Lambda function for each completed 
+      (non-partial) transcript segment. The function can capture and/or modify the text of the transcript, for example to implement custom
+      redaction logic, profanity filtering, or custom rules to highlight patterns in the transcript.
+
+  TranscriptLambdaHookFunctionNonPartialOnly:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >
+      Specifies if Transcript Lambda Hook Function (if specified) is invoked for Non-Partial transcript segments only (true), or for
+      both Partial and Non-Partial transcript segments (false).
+
   CloudFrontPriceClass:
     Type: String
     Default: PriceClass_100
@@ -234,12 +253,17 @@ Metadata:
         default: Enable Sentiment Analysis with Comprehend
       ComprehendLanguageCode:
         default: Comprehend Sentiment Analysis Language Code
+      TranscriptLambdaHookFunctionArn:
+        default: Lambda Hook Function ARN for Custom Transcript Segment Processing (existing)
+      TranscriptLambdaHookFunctionNonPartialOnly:
+        default: Lambda Hook Function Mode Non-Partial only
 
 Conditions:
   ShouldCreateRecordingBucket: !Equals [!Ref S3BucketName, ""]
   ShouldAllowSignUpEmailDomain: !Not [!Equals [!Ref AllowedSignUpEmailDomain, ""]]
   ShouldEnableGeoRestriction: !Not [!Equals [!Ref CloudFrontAllowedGeos, '']]
   ShouldEnableLambdaAgentAssist: !Equals [!Ref IsLambdaAgentAssistEnabled, "true"]
+  ShouldEnableTranscriptLambdaHookFunction: !Not [!Equals [!Ref TranscriptLambdaHookFunctionArn, ""]]
 
 Outputs:
   CallDataStreamName:
@@ -687,8 +711,13 @@ Resources:
                   - lambda:InvokeFunction
                 Resource: !Sub "${AgentAssistExistingLambdaFunctionArn}"
               - Ref: AWS::NoValue
-
-
+            - !If 
+              - ShouldEnableTranscriptLambdaHookFunction
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource: !Sub "${TranscriptLambdaHookFunctionArn}"
+              - Ref: AWS::NoValue
       Runtime: python3.9
       Timeout: 60
       Environment:
@@ -714,6 +743,8 @@ Resources:
           IS_LAMBDA_AGENT_ASSIST_ENABLED: !Ref IsLambdaAgentAssistEnabled
           LAMBDA_AGENT_ASSIST_FUNCTION_ARN: !Ref AgentAssistExistingLambdaFunctionArn
           DYNAMODB_EXPIRATION_IN_DAYS: !Ref DynamoDbExpirationInDays
+          TRANSCRIPT_LAMBDA_HOOK_FUNCTION_ARN: !Ref TranscriptLambdaHookFunctionArn
+          TRANSCRIPT_LAMBDA_HOOK_FUNCTION_NONPARTIAL_ONLY: !Ref TranscriptLambdaHookFunctionNonPartialOnly
 
   ##########################################################################
   # Transcript Enrichment Lambda Layers

--- a/lca-ai-stack/source/appsync/schema.graphql
+++ b/lca-ai-stack/source/appsync/schema.graphql
@@ -29,6 +29,7 @@ type Call implements DynamoDbBase @aws_cognito_user_pools
 	RecordingUrl: String
 	TotalConversationDurationMillis: Float
 	AgentId: String
+	Metadatajson: String
 }
 
 type CallList @aws_cognito_user_pools
@@ -65,6 +66,7 @@ input CreateCallInput {
 	AgentId: String
 	CustomerPhoneNumber: String
 	SystemPhoneNumber: String
+	Metadatajson: String
 	ExpiresAfter: AWSTimestamp
 }
 

--- a/lca-chimevc-stack/LambdaHookFunction.md
+++ b/lca-chimevc-stack/LambdaHookFunction.md
@@ -12,6 +12,7 @@ LCA v0.5.0 and later offers optional custom logic via a user-provided Lambda fun
 5. Override the default toNumber (System Phone number)
 6. Override the default fromNumber (Caller Phone number)
 7. Selectively choose whether to save call recording to S3
+8. Attach optional arbitrary metadata json object to call record, for use by downstream custom applications via the LCA graphQL API or DynamoDB event sourcing table. NOTE metadatajson values are not currently used by the LCA UI.
 
 To use this feature:
 1. Implement a Lambda function with the desired business logic
@@ -31,7 +32,8 @@ Your Lambda implements your required business logic, and returns a simple JSON s
             agentId: <string>,
             fromNumber: <string>,
             toNumber: <string>,
-            shouldRecordCall: <boolean>
+            shouldRecordCall: <boolean>,
+            metadatajson: <string>
           }
 ``` 
 Here is a minimal example of a valid custom Lambda hook function, written in node.js
@@ -47,6 +49,7 @@ exports.handler = async (event) => {
             fromNumber: "Bob's cell",
             toNumber: "Demo Asterisk",
             shouldRecordCall: false,
+            metadatajson: JSON.stringify({key1:"value1", key2:"value2"}),
           }
     return response;
 };
@@ -59,6 +62,7 @@ This minimal function:
 - replaces the `fromNumber` value with a (hardcoded) string
 - replaces the `toNumber` value with a (hardcoded) string
 - disables call audio recording
+- adds metadata to the call, as an arbitrary JSON string - metadata is written 
 
 Your function will be much smarter, possibly interacting with your IVR or CRM to determine the desired behavior.
 
@@ -68,14 +72,14 @@ If your function provides a valid response, the LCA ChimeVC CallTranscriber proc
 ```
 INFO Invoking LambdaHook: arn:aws:lambda:us-east-1:XXXXXXXXXXXX:function:testLambdaHook
 INFO LambdaHook response: {"originalCallId":"cfaafd64-0eed-4fdd-9699-321b6ce14d54","shouldProcessCall":true,"isCaller":false,"callId":...
-INFO Lambda hook returned shouldProcessCall=true, continuing.
 INFO Lambda hook returned new callId: "MODIFIED-cfaafd64-0eed-4fdd-9699-321b6ce14d54"
 INFO Lambda hook returned isCaller=false, swapping caller/agent streams
 INFO Lambda hook returned agentId: "Bob the Builder"
 INFO Lambda hook returned fromNumber: "Bob's cell"
 INFO Lambda hook returned toNumber: "Demo Asterisk"
+INFO Lambda hook returned metadatajson: "{"key1":"value1","key2":"value2"}"
+INFO Lambda hook returned shouldProcessCall=true, continuing.
 INFO Lambda hook returned shouldRecordCall=false, audio recording disabled.
-
 ```
 
 If your function response sets `shouldProcessCall` to `false` the CallTranscriber function logs a message and exits without processing the call. No other response fields matter in this case.

--- a/lca-chimevc-stack/LambdaHookFunction.md
+++ b/lca-chimevc-stack/LambdaHookFunction.md
@@ -11,6 +11,7 @@ LCA v0.5.0 and later offers optional custom logic via a user-provided Lambda fun
 4. Override the default CallId with another unique value for the call
 5. Override the default toNumber (System Phone number)
 6. Override the default fromNumber (Caller Phone number)
+7. Selectively choose whether to save call recording to S3
 
 To use this feature:
 1. Implement a Lambda function with the desired business logic
@@ -29,7 +30,8 @@ Your Lambda implements your required business logic, and returns a simple JSON s
             callId: <string>,
             agentId: <string>,
             fromNumber: <string>,
-            toNumber: <string>
+            toNumber: <string>,
+            shouldRecordCall: <boolean>
           }
 ``` 
 Here is a minimal example of a valid custom Lambda hook function, written in node.js
@@ -43,7 +45,8 @@ exports.handler = async (event) => {
             callId: `MODIFIED-${event.detail.callId}`,
             agentId: "Bob the Builder",
             fromNumber: "Bob's cell",
-            toNumber: "Demo Asterisk"
+            toNumber: "Demo Asterisk",
+            shouldRecordCall: false,
           }
     return response;
 };
@@ -55,6 +58,7 @@ This minimal function:
 - assigns a (hardcoded) agentId to the call
 - replaces the `fromNumber` value with a (hardcoded) string
 - replaces the `toNumber` value with a (hardcoded) string
+- disables call audio recording
 
 Your function will be much smarter, possibly interacting with your IVR or CRM to determine the desired behavior.
 
@@ -70,6 +74,8 @@ INFO Lambda hook returned isCaller=false, swapping caller/agent streams
 INFO Lambda hook returned agentId: "Bob the Builder"
 INFO Lambda hook returned fromNumber: "Bob's cell"
 INFO Lambda hook returned toNumber: "Demo Asterisk"
+INFO Lambda hook returned shouldRecordCall=false, audio recording disabled.
+
 ```
 
 If your function response sets `shouldProcessCall` to `false` the CallTranscriber function logs a message and exits without processing the call. No other response fields matter in this case.

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -186,6 +186,7 @@ const writeCallStartEventToKds = async function (callData) {
     CustomerPhoneNumber: callData.fromNumber,
     SystemPhoneNumber: callData.toNumber,
     AgentId: callData.agentId,
+    Metadatajson: callData.metadatajson,
     EventType: "START",
   };
   const putParams = {
@@ -245,6 +246,7 @@ const getCallDataFromChimeEvents = async function (callEvent) {
     fromNumber: callEvent.detail.fromNumber,
     toNumber: callEvent.detail.toNumber,
     agentId: callEvent.detail.agentId,
+    metadatajson: undefined,
     callerStreamArn: callerStreamArn,
     agentStreamArn: agentStreamArn,
     lambdaCount: 0,
@@ -278,6 +280,7 @@ const getCallDataFromChimeEvents = async function (callEvent) {
           fromNumber: <string>,
           toNumber: <string>,
           shouldRecordCall: <boolean>,
+          metadatajson: <string>
         }
     */
 
@@ -310,6 +313,12 @@ const getCallDataFromChimeEvents = async function (callEvent) {
     if (payload.toNumber) {
       console.log(`Lambda hook returned toNumber: "${payload.toNumber}"`);
       callData.toNumber = payload.toNumber;
+    }
+
+    // Metadata?
+    if (payload.metadatajson) {
+      console.log(`Lambda hook returned metadatajson: "${payload.metadatajson}"`);
+      callData.metadatajson = payload.metadatajson;
     }
 
     // Should we process this call?

--- a/lca-main.yaml
+++ b/lca-main.yaml
@@ -184,6 +184,25 @@ Parameters:
       - 'true'
       - 'false'
 
+  TranscriptLambdaHookFunctionArn:
+    Default: ''
+    Type: String
+    AllowedPattern: '^(|arn:aws:lambda:.*)$'
+    Description: >
+      (Optional) If present, the specified Lambda function is invoked by the LCA Call Event Processor Lambda function for each completed 
+      (non-partial) transcript segment. The function can capture and/or modify the text of the transcript, for example to implement custom
+      redaction logic, profanity filtering, or custom rules to highlight patterns in the transcript. 
+
+  TranscriptLambdaHookFunctionNonPartialOnly:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >
+      Specifies if Transcript Lambda Hook Function (if specified) is invoked for Non-Partial transcript segments only (true), or for
+      both Partial and Non-Partial transcript segments (false).
+
   AdminEmail:
     Type: String
     Description: >-
@@ -280,9 +299,11 @@ Metadata:
           - TranscribePiiEntityTypes
           - CustomVocabularyName
       - Label:
-          default: Amazon Comprehend Configuration
+          default: Transcript Event Processing Configuration
         Parameters:
           - IsSentimentAnalysisEnabled
+          - TranscriptLambdaHookFunctionArn
+          - TranscriptLambdaHookFunctionNonPartialOnly
       - Label:
           default: Download locations
         Parameters:
@@ -342,6 +363,10 @@ Metadata:
         default: Demo Asterisk Server Agent WAV File Download URL
       IsSentimentAnalysisEnabled:
         default: Enable Sentiment Analysis using Amazon Comprehend
+      TranscriptLambdaHookFunctionArn:
+        default: Lambda Hook Function ARN for Custom Transcript Segment Processing (existing)
+      TranscriptLambdaHookFunctionNonPartialOnly:
+        default: Lambda Hook Function Mode Non-Partial only
       CloudFrontPriceClass:
         default: CloudFront Price Class
       CloudFrontAllowedGeos:
@@ -550,6 +575,8 @@ Resources:
             - false
         AgentAssistExistingLambdaFunctionArn: !Ref AgentAssistExistingLambdaFunctionArn
         DynamoDbExpirationInDays: !Ref DynamoDbExpirationInDays
+        TranscriptLambdaHookFunctionArn: !Ref TranscriptLambdaHookFunctionArn
+        TranscriptLambdaHookFunctionNonPartialOnly: !Ref TranscriptLambdaHookFunctionNonPartialOnly
 
   AGENTASSISTSETUP:
     Type: AWS::CloudFormation::Stack
@@ -579,6 +606,17 @@ Resources:
           - !GetAtt QNABOT.Outputs.LexV2BotAliasId
           - !Ref AgentAssistExistingLexV2BotAliasId
         QnaAgentAssistDemoJson: <ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-agentassist-setup-stack/qna-aa-demo.jsonl
+        # Changes to Params below force AgentAssist Setup to update.
+        AgentAssistOption: !Ref AgentAssistOption
+        AgentAssistExistingKendraIndexId: !Ref AgentAssistExistingKendraIndexId
+        AgentAssistExistingLexV2BotId: !Ref AgentAssistExistingLexV2BotId
+        AgentAssistExistingLexV2BotAliasId: !Ref AgentAssistExistingLexV2BotAliasId
+        AgentAssistExistingLambdaFunctionArn: !Ref AgentAssistExistingLambdaFunctionArn
+        TranscribeLanguageCode: !Ref TranscribeLanguageCode
+        IsSentimentAnalysisEnabled: !Ref IsSentimentAnalysisEnabled
+        TranscriptLambdaHookFunctionArn: !Ref TranscriptLambdaHookFunctionArn
+        TranscriptLambdaHookFunctionNonPartialOnly: !Ref TranscriptLambdaHookFunctionNonPartialOnly
+        DynamoDbExpirationInDays: !Ref DynamoDbExpirationInDays
 
   CHIMEVCSTACK:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
*Description of changes:*

Add optional custom logic via a user-provided Lambda function, to support the following features:
1. Modify Transcriptions in real time using custom logic, for example, implement your redaction or profanity filtering rules.
2. Choose to process non-partial (final) transcript segments only, or both partial (not final) and non-partial (final) transcript segments.
3. Log or save transcript segments to an external data store.

PR also includes improvements to ensure that AgentAssistSetup stack / function runs after modifying stack parameters that cause CallEventProcessor function to be replaced (previously stack updates could result in Lex Bot environment variables being reset to null).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
