### PR TITLE
Pass the normalized message to the lambda hook

### DIFF
--- a/lca-ai-stack/source/lambda_functions/call_event_processor/event_processor/transcribe.py
+++ b/lca-ai-stack/source/lambda_functions/call_event_processor/event_processor/transcribe.py
@@ -981,7 +981,7 @@ async def execute_process_event_api_mutation(
         }
 
         if (TRANSCRIPT_LAMBDA_HOOK_FUNCTION_ARN):
-            message = invoke_transcript_lambda_hook(message)
+            normalized_message = invoke_transcript_lambda_hook(normalized_message)
 
         issues_detected = normalized_message.get("IssuesDetected", None)
         if issues_detected and len(issues_detected) > 0:


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
This is to fix a bug that caused bypassing the invocation of the Lambda hook. Changed the value passed into the invoke_transcript_lambda_hook function to the normalized message which is a normalized/standardized version of the inbound call segment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
