### PR TITLE
Start call analytics based on START_CALL_PROCESSING

### DIFF
--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-call-analytics.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-call-analytics.yaml
@@ -322,45 +322,35 @@ Resources:
         import cfnresponse
         import uuid
         import traceback
-        
+       
         responseData = {}
-        
+       
         voiceClient = boto3.client('chime-sdk-voice')
         mediaPipelineClient = boto3.client('chime-sdk-media-pipelines')
         cloudformation = boto3.resource("cloudformation")
-        
+       
         def is_valid_uuid(value):
           try:
             uuid.UUID(str(value))
-        
+       
             return True
           except ValueError:
             return False
-        
+       
         def delete_pipeline_config(event):
           id = event.get('PhysicalResourceId','')
-          pipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-' + id
-          result = mediaPipelineClient.delete_media_insights_pipeline_configuration(Identifier=pipelineConfigName)
+       
+          transcribePipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-ts-' + id
+          transcribeResult = mediaPipelineClient.delete_media_insights_pipeline_configuration(Identifier=transcribePipelineConfigName)
+       
+          voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-va-' + id
+          voiceAnalyticsResult = mediaPipelineClient.delete_media_insights_pipeline_configuration(Identifier=voiceAnalyticsPipelineConfigName)
+       
           return {'PhysicalResourceId': id}
-        
-        def find_media_pipeline_config(event):
-          print('finding media pipeline')
-          try:
-            id = event.get('PhysicalResourceId','')
-            pipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-' + id
-            response = mediaPipelineClient.get_media_insights_pipeline_configuration(Identifier=pipelineConfigName)
-            return {
-              'ConfigArn': response['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
-              'PhysicalResourceId': id
-            }
-          except Exception as e:
-            error = f'Exception thrown: {e}.'
-            print(error)
-            return None
-        
-        def generate_config(event, pipelineConfigName, resourceAccessRoleArn ):
+       
+        def generate_voice_analytics_config(event, pipelineConfigName, resourceAccessRoleArn ):
           elements = []
-        
+       
           # configure kds
           kdsArn = event['ResourceProperties'].get('KinesisStreamArn', '')
           kds = {
@@ -370,7 +360,45 @@ Resources:
               }
           }
           elements.append(kds)
-          
+       
+          # configure lambda sink
+          lambdaSinkArn = event['ResourceProperties'].get('LambdaSinkArn', '')
+          lambdaSink = {
+            "Type": "LambdaFunctionSink",
+            "LambdaFunctionSinkConfiguration": {
+              "InsightsTarget": lambdaSinkArn
+            }
+          }
+          elements.append(lambdaSink)
+       
+          # configure voice analytics
+          enableVoiceToneAnalysis = event['ResourceProperties'].get('EnableVoiceToneAnalysis', '')
+          enableSpeakerSearch = event['ResourceProperties'].get('EnableSpeakerSearch', '')
+          voiceAnalytics =  {
+            "Type": "VoiceAnalyticsProcessor",
+            "VoiceAnalyticsProcessorConfiguration": {
+              "VoiceToneAnalysisStatus": 'Enabled' if enableVoiceToneAnalysis == 'true' else 'Disabled',
+              "SpeakerSearchStatus": 'Enabled' if enableSpeakerSearch == 'true' else 'Disabled'
+            }
+          }
+          elements.append(voiceAnalytics)
+          print("Voice analytics configuration")
+          print(json.dumps(elements))
+          return elements
+       
+        def generate_transcribe_config(event, pipelineConfigName, resourceAccessRoleArn ):
+          elements = []
+       
+          # configure kds
+          kdsArn = event['ResourceProperties'].get('KinesisStreamArn', '')
+          kds = {
+              "Type": "KinesisDataStreamSink",
+              "KinesisDataStreamSinkConfiguration": {
+                  "InsightsTarget": kdsArn
+              }
+          }
+          elements.append(kds)
+       
           # configure transcribe
           transcribeApiMode = event['ResourceProperties'].get('TranscribeApiMode', '')
           transcribeLanguageCode = event['ResourceProperties'].get('TranscribeLanguageCode', '')
@@ -386,14 +414,14 @@ Resources:
           recordingFilePrefix = event['ResourceProperties'].get('RecordingFilePrefix', '')
           tcaDataAccessRoleArn = event['ResourceProperties'].get('TcaDataAccessRoleArn', '')
           outputLocation = "s3://%s/%s"%(outputBucket,callAnalyticsFilePrefix)
-          
+       
           if transcribeApiMode == 'analytics':
             transcribeConfig = "AmazonTranscribeCallAnalyticsProcessorConfiguration"
             transcribe = {
               "Type":"AmazonTranscribeCallAnalyticsProcessor",
-              "AmazonTranscribeCallAnalyticsProcessorConfiguration": { 
+              "AmazonTranscribeCallAnalyticsProcessorConfiguration": {
                 "LanguageCode": transcribeLanguageCode,
-                "PostCallAnalyticsSettings": { 
+                "PostCallAnalyticsSettings": {
                   "DataAccessRoleArn": tcaDataAccessRoleArn,
                   "OutputLocation": outputLocation
                 }
@@ -417,100 +445,110 @@ Resources:
           if customVocabularyName:
             transcribe[transcribeConfig]["VocabularyName"] = customVocabularyName
           elements.append(transcribe)
-              
-          # configure lambda sink
-          lambdaSinkArn = event['ResourceProperties'].get('LambdaSinkArn', '')
-          lambdaSink = {
-            "Type": "LambdaFunctionSink",
-            "LambdaFunctionSinkConfiguration": {
-              "InsightsTarget": lambdaSinkArn
-            }
-          }
-          elements.append(lambdaSink)
-          
-          # configure voice analytics
-          enableVoiceToneAnalysis = event['ResourceProperties'].get('EnableVoiceToneAnalysis', '')
-          enableSpeakerSearch = event['ResourceProperties'].get('EnableSpeakerSearch', '')
-          voiceAnalytics =  {
-            "Type": "VoiceAnalyticsProcessor",
-            "VoiceAnalyticsProcessorConfiguration": {
-              "VoiceToneAnalysisStatus": 'Enabled' if enableVoiceToneAnalysis == 'true' else 'Disabled',
-              "SpeakerSearchStatus": 'Enabled' if enableSpeakerSearch == 'true' else 'Disabled'
-            }
-          }
-          elements.append(voiceAnalytics)
+       
+          print("Media pipeline configuration")
           print(json.dumps(elements))
           return elements
-        
+       
         def update_media_pipeline_config(event):
           id = event.get('PhysicalResourceId')
-          pipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-' + id
-          print("Updating media pipeline config: ", pipelineConfigName)
           resourceAccessRoleArn = event['ResourceProperties'].get('ResourceAccessRoleArn', '')
-          elements = generate_config(event, pipelineConfigName, resourceAccessRoleArn)
-          response = mediaPipelineClient.update_media_insights_pipeline_configuration(
-            Identifier=pipelineConfigName,
+       
+          transcribePipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-ts-' + id
+          transcribeElements = generate_transcribe_config(event, transcribePipelineConfigName, resourceAccessRoleArn)
+          print("Updating transcribe media pipeline config: ", transcribePipelineConfigName)
+          transcribeResponse = mediaPipelineClient.update_media_insights_pipeline_configuration(
+            Identifier=transcribePipelineConfigName,
             ResourceAccessRoleArn=resourceAccessRoleArn,
             RealTimeAlertConfiguration={
               'Disabled': True
             },
-            Elements=elements
+            Elements=transcribeElements
           )
+       
+          voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-va-' + id
+          voiceAnalyticsElements = generate_voice_analytics_config(event, voiceAnalyticsPipelineConfigName, resourceAccessRoleArn)
+          print("Updating voice analytics media pipeline config: ", voiceAnalyticsPipelineConfigName)
+          voiceAnalyticsResponse = mediaPipelineClient.update_media_insights_pipeline_configuration(
+            Identifier=voiceAnalyticsPipelineConfigName,
+            ResourceAccessRoleArn=resourceAccessRoleArn,
+            RealTimeAlertConfiguration={
+              'Disabled': True
+            },
+            Elements=voiceAnalyticsElements
+          )
+       
           return {
-            'ConfigArn': response['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'], 
+            'VoiceAnalyticsConfigArn': voiceAnalyticsResponse['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
+            'ConfigArn': transcribeResponse['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
             'PhysicalResourceId': id
           }
-        
+       
         def create_media_pipeline_config(event):
           print('creating media pipeline configuration')
           id = str(uuid.uuid4())
-          pipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-' + id 
           resourceAccessRoleArn = event['ResourceProperties'].get('ResourceAccessRoleArn', '')
-        
-          elements = generate_config(event, pipelineConfigName, resourceAccessRoleArn)
-          
-          response = mediaPipelineClient.create_media_insights_pipeline_configuration(
-            MediaInsightsPipelineConfigurationName=pipelineConfigName,
+       
+          transcribePipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-ts-' + id
+          transcribeElements = generate_transcribe_config(event, transcribePipelineConfigName, resourceAccessRoleArn)
+          print("Creating transcribe media pipeline config: ", transcribePipelineConfigName)
+          transcribeResponse = mediaPipelineClient.create_media_insights_pipeline_configuration(
+            MediaInsightsPipelineConfigurationName=transcribePipelineConfigName,
             ResourceAccessRoleArn=resourceAccessRoleArn,
             RealTimeAlertConfiguration={
               'Disabled': True
             },
-            Elements=elements
+            Elements=transcribeElements
           )
-          
+       
+          voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-va-' + id
+          voiceAnalyticsElements = generate_voice_analytics_config(event, voiceAnalyticsPipelineConfigName, resourceAccessRoleArn)
+          print("Creating voice analytics media pipeline config: ", voiceAnalyticsPipelineConfigName)
+          voiceAnalyticsResponse = mediaPipelineClient.create_media_insights_pipeline_configuration(
+            MediaInsightsPipelineConfigurationName=voiceAnalyticsPipelineConfigName,
+            ResourceAccessRoleArn=resourceAccessRoleArn,
+            RealTimeAlertConfiguration={
+              'Disabled': True
+            },
+            Elements=voiceAnalyticsElements
+          )
+       
           return {
-            'ConfigArn': response['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
+            'VoiceAnalyticsConfigArn': voiceAnalyticsResponse['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
+            'ConfigArn': transcribeResponse['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
             'PhysicalResourceId': id
           }
-          
-        
+       
+       
         def get_vc_configuration(event):
-          voiceConnectorId = event['ResourceProperties']['VoiceConnectorId'] 
+          voiceConnectorId = event['ResourceProperties']['VoiceConnectorId']
           print(f"Getting existing configuration... {voiceConnectorId}")
-          
+       
           try:
             response = voiceClient.get_voice_connector_streaming_configuration(VoiceConnectorId=voiceConnectorId)
             streamingConfiguration = response["StreamingConfiguration"]
+            print("Voice connector streaming configuration")
             print(json.dumps(streamingConfiguration))
             return streamingConfiguration
           except Exception as e:
             error = f'Error getting voice connector streaming config: {e}.'
             print(error)
           return None
-              
+       
         def update_vc_configuration(event, config_arn, delete=False):
           print("Updating VC configuration")
-          voiceConnectorId = event['ResourceProperties']['VoiceConnectorId'] 
+          voiceConnectorId = event['ResourceProperties']['VoiceConnectorId']
           streamingConfiguration = get_vc_configuration(event)
-          
+       
           if streamingConfiguration is None:
             # nothing to do?
             return None
-          
+       
           if event['ResourceProperties']['EnableVoiceToneAnalysis'] == 'true' and delete == False:
             print("Enabling Voice Tone Analysis...")
             streamingConfiguration['MediaInsightsConfiguration'] = {
-              "ConfigurationArn": config_arn
+              "ConfigurationArn": config_arn,
+              "Disabled": False
             }
           else:
             print("Disabling Voice Tone Analysis/Removing Streaming Config from VC")
@@ -524,15 +562,7 @@ Resources:
             )
           print(response)
           return response
-        
-        def delete_vc_configuration(event):
-          voiceConnectorId = event['ResourceProperties']['VoiceConnectorId'] 
-          response = voiceClient.delete_voice_connector_streaming_configuration(
-            VoiceConnectorId=voiceConnectorId
-          )
-          print(response)
-          return response
-        
+       
         def lambda_handler(event, context):
           print(event)
           responseData = {
@@ -541,11 +571,11 @@ Resources:
           try:
             if event['RequestType'] == "Create":
               responseData = create_media_pipeline_config(event)
-              update_vc_configuration(event, responseData['ConfigArn'])
+              update_vc_configuration(event, responseData['VoiceAnalyticsConfigArn'])
               cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, responseData['PhysicalResourceId'])
             elif event['RequestType'] == "Update":
               responseData = update_media_pipeline_config(event)
-              update_vc_configuration(event, responseData['ConfigArn'])
+              update_vc_configuration(event, responseData['VoiceAnalyticsConfigArn'])
               cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, responseData['PhysicalResourceId'])
             else:
               update_vc_configuration(event, None, True)
@@ -757,6 +787,10 @@ Resources:
                 Resource:
                   - !GetAtt CreateMediaPipelineConfigForVC.ConfigArn
                   - !Sub "arn:${AWS::Partition}:chime:${AWS::Region}:${AWS::AccountId}:media-pipeline/*"
+              - Effect: Allow
+                Action:
+                  - chime:StartVoiceToneAnalysisTask
+                Resource: "*"
               - Effect: Allow
                 Action:
                   - chime:GetMediaPipeline

--- a/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/package.json
+++ b/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "chime_call_analytics_initialization",
+  "version": "1.0.0",
+  "description": "This lambda creates media insight pipeline and optional voice tone analysis",
+  "main": "index.js",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.312.0",
+    "@aws-sdk/client-kinesis": "^3.312.0",
+    "@aws-sdk/client-lambda": "^3.312.0",
+    "@aws-sdk/client-chime-sdk-media-pipelines": "^3.312.0",
+    "@aws-sdk/client-chime-sdk-voice": "^3.312.0"
+  }
+}

--- a/lca-chimevc-stack/lambda_layers/node_transcriber_layer/package.json
+++ b/lca-chimevc-stack/lambda_layers/node_transcriber_layer/package.json
@@ -11,6 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/client-chime-sdk-media-pipelines": "^3.312.0",
+    "@aws-sdk/client-chime-sdk-voice": "^3.312.0",
     "@aws-sdk/client-dynamodb": "^3.312.0",
     "@aws-sdk/client-eventbridge": "^3.312.0",
     "@aws-sdk/client-kinesis": "^3.312.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allow starting Amazon Chime SDK transcription, call analytics, and tone
analysis when START_CALL_PROCESS event is sent rather at the start of
the call. LAMBDA_HOOK_FUNCTION_ARN can return shouldProcessCall = false
so that Chime SDK Call Analytics is not started automatically.

Test
Manually tested with LCA deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
