### PR TITLE
Fix call analytics update resource

### DIFF
--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-call-analytics.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-call-analytics.yaml
@@ -252,6 +252,7 @@ Resources:
 
   ##########################################################################
   # Custom resource to apply config to VoiceConnector
+  # Increment CustomResourceVersion when making changes to CreateMediaPipelineConfigForVCFunction
   ##########################################################################
 
   CreateMediaPipelineConfigForVC:
@@ -284,6 +285,7 @@ Resources:
       PiiEntityTypes: !Ref TranscribePiiEntityTypes
       CustomVocabularyName: !Ref CustomVocabularyName
       CustomLanguageModelName: !Ref CustomLanguageModelName
+      CustomResourceVersion: '1.1'
 
   CreateMediaPipelineConfigForVCFunction:
     Type: AWS::Serverless::Function
@@ -301,6 +303,7 @@ Resources:
               - chime:CreateMediaInsightsPipelineConfiguration
               - chime:DeleteMediaInsightsPipelineConfiguration
               - chime:UpdateMediaInsightsPipelineConfiguration
+              - chime:GetMediaInsightsPipelineConfiguration
               - chime:ListMediaInsightsPipelineConfigurations
               - chime:GetMediaInsightsPipelineConfiguration
             Resource: !Sub arn:${AWS::Partition}:chime:${AWS::Region}:${AWS::AccountId}:*
@@ -322,35 +325,43 @@ Resources:
         import cfnresponse
         import uuid
         import traceback
-       
+        
         responseData = {}
-       
+        
         voiceClient = boto3.client('chime-sdk-voice')
         mediaPipelineClient = boto3.client('chime-sdk-media-pipelines')
         cloudformation = boto3.resource("cloudformation")
-       
+        
         def is_valid_uuid(value):
           try:
             uuid.UUID(str(value))
-       
+        
             return True
           except ValueError:
             return False
-       
+        
         def delete_pipeline_config(event):
           id = event.get('PhysicalResourceId','')
-       
-          transcribePipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-ts-' + id
-          transcribeResult = mediaPipelineClient.delete_media_insights_pipeline_configuration(Identifier=transcribePipelineConfigName)
-       
-          voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-va-' + id
-          voiceAnalyticsResult = mediaPipelineClient.delete_media_insights_pipeline_configuration(Identifier=voiceAnalyticsPipelineConfigName)
-       
+
+          try:
+            transcribePipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-ts-' + id
+            mediaPipelineClient.delete_media_insights_pipeline_configuration(Identifier=transcribePipelineConfigName)
+          except Exception as e:
+            error = f'Error deleting transcribe media insight pipeline config: {e}.'
+            print(error)
+
+          try:
+            voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-' + id
+            mediaPipelineClient.delete_media_insights_pipeline_configuration(Identifier=voiceAnalyticsPipelineConfigName)
+          except Exception as e:
+            error = f'Error deleting voice analytics media insight pipeline config: {e}.'
+            print(error)
+        
           return {'PhysicalResourceId': id}
-       
+        
         def generate_voice_analytics_config(event, pipelineConfigName, resourceAccessRoleArn ):
           elements = []
-       
+        
           # configure kds
           kdsArn = event['ResourceProperties'].get('KinesisStreamArn', '')
           kds = {
@@ -360,7 +371,7 @@ Resources:
               }
           }
           elements.append(kds)
-       
+        
           # configure lambda sink
           lambdaSinkArn = event['ResourceProperties'].get('LambdaSinkArn', '')
           lambdaSink = {
@@ -370,7 +381,7 @@ Resources:
             }
           }
           elements.append(lambdaSink)
-       
+        
           # configure voice analytics
           enableVoiceToneAnalysis = event['ResourceProperties'].get('EnableVoiceToneAnalysis', '')
           enableSpeakerSearch = event['ResourceProperties'].get('EnableSpeakerSearch', '')
@@ -385,10 +396,10 @@ Resources:
           print("Voice analytics configuration")
           print(json.dumps(elements))
           return elements
-       
+        
         def generate_transcribe_config(event, pipelineConfigName, resourceAccessRoleArn ):
           elements = []
-       
+        
           # configure kds
           kdsArn = event['ResourceProperties'].get('KinesisStreamArn', '')
           kds = {
@@ -398,7 +409,7 @@ Resources:
               }
           }
           elements.append(kds)
-       
+        
           # configure transcribe
           transcribeApiMode = event['ResourceProperties'].get('TranscribeApiMode', '')
           transcribeLanguageCode = event['ResourceProperties'].get('TranscribeLanguageCode', '')
@@ -414,7 +425,7 @@ Resources:
           recordingFilePrefix = event['ResourceProperties'].get('RecordingFilePrefix', '')
           tcaDataAccessRoleArn = event['ResourceProperties'].get('TcaDataAccessRoleArn', '')
           outputLocation = "s3://%s/%s"%(outputBucket,callAnalyticsFilePrefix)
-       
+        
           if transcribeApiMode == 'analytics':
             transcribeConfig = "AmazonTranscribeCallAnalyticsProcessorConfiguration"
             transcribe = {
@@ -445,50 +456,75 @@ Resources:
           if customVocabularyName:
             transcribe[transcribeConfig]["VocabularyName"] = customVocabularyName
           elements.append(transcribe)
-       
+        
           print("Media pipeline configuration")
           print(json.dumps(elements))
           return elements
-       
+        
         def update_media_pipeline_config(event):
           id = event.get('PhysicalResourceId')
           resourceAccessRoleArn = event['ResourceProperties'].get('ResourceAccessRoleArn', '')
-       
+
           transcribePipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-ts-' + id
           transcribeElements = generate_transcribe_config(event, transcribePipelineConfigName, resourceAccessRoleArn)
-          print("Updating transcribe media pipeline config: ", transcribePipelineConfigName)
-          transcribeResponse = mediaPipelineClient.update_media_insights_pipeline_configuration(
-            Identifier=transcribePipelineConfigName,
-            ResourceAccessRoleArn=resourceAccessRoleArn,
-            RealTimeAlertConfiguration={
-              'Disabled': True
-            },
-            Elements=transcribeElements
-          )
-       
-          voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-va-' + id
+          transcribeMediaPipelineConfiguration = get_media_pipeline_config(transcribePipelineConfigName)
+          if transcribeMediaPipelineConfiguration is None:
+            print("Creating transcribe media pipeline config: ", transcribePipelineConfigName)
+            transcribeResponse = mediaPipelineClient.create_media_insights_pipeline_configuration(
+              MediaInsightsPipelineConfigurationName=transcribePipelineConfigName,
+              ResourceAccessRoleArn=resourceAccessRoleArn,
+              RealTimeAlertConfiguration={
+                  'Disabled': True
+              },
+              Elements=transcribeElements
+            )
+          else:
+            print("Updating transcribe media pipeline config: ", transcribePipelineConfigName)
+            transcribeResponse = mediaPipelineClient.update_media_insights_pipeline_configuration(
+              Identifier=transcribePipelineConfigName,
+              ResourceAccessRoleArn=resourceAccessRoleArn,
+        
+              RealTimeAlertConfiguration={
+                'Disabled': True
+              },
+              Elements=transcribeElements
+            )
+        
+          voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-' + id
           voiceAnalyticsElements = generate_voice_analytics_config(event, voiceAnalyticsPipelineConfigName, resourceAccessRoleArn)
-          print("Updating voice analytics media pipeline config: ", voiceAnalyticsPipelineConfigName)
-          voiceAnalyticsResponse = mediaPipelineClient.update_media_insights_pipeline_configuration(
-            Identifier=voiceAnalyticsPipelineConfigName,
-            ResourceAccessRoleArn=resourceAccessRoleArn,
-            RealTimeAlertConfiguration={
-              'Disabled': True
-            },
-            Elements=voiceAnalyticsElements
-          )
-       
+          voiceAnalyticsPipelineConfiguration = get_media_pipeline_config(voiceAnalyticsPipelineConfigName)
+          if voiceAnalyticsPipelineConfiguration is None:
+            print("Creating voice analytics media pipeline config: ", voiceAnalyticsPipelineConfigName)
+            voiceAnalyticsResponse = mediaPipelineClient.create_media_insights_pipeline_configuration(
+              MediaInsightsPipelineConfigurationName=voiceAnalyticsPipelineConfigName,
+              ResourceAccessRoleArn=resourceAccessRoleArn,
+              RealTimeAlertConfiguration={
+                  'Disabled': True
+              },
+              Elements=voiceAnalyticsElements
+            )
+          else:
+            print("Updating voice analytics media pipeline config: ", voiceAnalyticsPipelineConfigName)
+            voiceAnalyticsResponse = mediaPipelineClient.update_media_insights_pipeline_configuration(
+              Identifier=voiceAnalyticsPipelineConfigName,
+              ResourceAccessRoleArn=resourceAccessRoleArn,
+              RealTimeAlertConfiguration={
+                'Disabled': True
+              },
+              Elements=voiceAnalyticsElements
+            )
+        
           return {
             'VoiceAnalyticsConfigArn': voiceAnalyticsResponse['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
             'ConfigArn': transcribeResponse['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
             'PhysicalResourceId': id
           }
-       
+        
         def create_media_pipeline_config(event):
           print('creating media pipeline configuration')
           id = str(uuid.uuid4())
           resourceAccessRoleArn = event['ResourceProperties'].get('ResourceAccessRoleArn', '')
-       
+        
           transcribePipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-ts-' + id
           transcribeElements = generate_transcribe_config(event, transcribePipelineConfigName, resourceAccessRoleArn)
           print("Creating transcribe media pipeline config: ", transcribePipelineConfigName)
@@ -500,8 +536,8 @@ Resources:
             },
             Elements=transcribeElements
           )
-       
-          voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-va-' + id
+        
+          voiceAnalyticsPipelineConfigName = event['ResourceProperties'].get('StackName', '') + '-' + id
           voiceAnalyticsElements = generate_voice_analytics_config(event, voiceAnalyticsPipelineConfigName, resourceAccessRoleArn)
           print("Creating voice analytics media pipeline config: ", voiceAnalyticsPipelineConfigName)
           voiceAnalyticsResponse = mediaPipelineClient.create_media_insights_pipeline_configuration(
@@ -512,18 +548,18 @@ Resources:
             },
             Elements=voiceAnalyticsElements
           )
-       
+        
           return {
             'VoiceAnalyticsConfigArn': voiceAnalyticsResponse['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
             'ConfigArn': transcribeResponse['MediaInsightsPipelineConfiguration']['MediaInsightsPipelineConfigurationArn'],
             'PhysicalResourceId': id
           }
-       
-       
+        
+        
         def get_vc_configuration(event):
           voiceConnectorId = event['ResourceProperties']['VoiceConnectorId']
           print(f"Getting existing configuration... {voiceConnectorId}")
-       
+        
           try:
             response = voiceClient.get_voice_connector_streaming_configuration(VoiceConnectorId=voiceConnectorId)
             streamingConfiguration = response["StreamingConfiguration"]
@@ -534,16 +570,32 @@ Resources:
             error = f'Error getting voice connector streaming config: {e}.'
             print(error)
           return None
-       
+
+        def get_media_pipeline_config(pipeline_identifier):
+          print(f"Getting existing media insight pipeline config... {pipeline_identifier}")
+
+          try:
+            response = mediaPipelineClient.get_media_insights_pipeline_configuration(Identifier=pipeline_identifier)
+            mediaPipelineConfiguration = response["MediaInsightsPipelineConfiguration"]
+            print("Media insight pipeline configuration already exists")
+            return mediaPipelineConfiguration
+          except mediaPipelineClient.exceptions.NotFoundException as nfe:
+            error = f'Media insight pipeline is not found: {nfe}.'
+            print(error)
+          except Exception as e:
+            error = f'Error getting existing media pipeline config: {e}.'
+            print(error)
+          return None
+        
         def update_vc_configuration(event, config_arn, delete=False):
           print("Updating VC configuration")
           voiceConnectorId = event['ResourceProperties']['VoiceConnectorId']
           streamingConfiguration = get_vc_configuration(event)
-       
+        
           if streamingConfiguration is None:
             # nothing to do?
             return None
-       
+        
           if event['ResourceProperties']['EnableVoiceToneAnalysis'] == 'true' and delete == False:
             print("Enabling Voice Tone Analysis...")
             streamingConfiguration['MediaInsightsConfiguration'] = {
@@ -562,7 +614,7 @@ Resources:
             )
           print(response)
           return response
-       
+        
         def lambda_handler(event, context):
           print(event)
           responseData = {


### PR DESCRIPTION
During update custom resource, two media insight pipleine configuration
is updated. If a media pipeline configuration does not exists due to
previous media pipeline configuration does not exists, create a new
media pipeline; Otherwise, update the media pipeline configuration.

Test
Upgrade from 0.8.0 with call analytics to 0.8.2 with call analytics
Upgrade from 0.8.0 with transcribe Lambda to 0.8.2 with call analytics

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
