### PR TITLE
Fix validation error: TemplateURL must be a supported URL

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -60,7 +60,7 @@ pwd
 dir=lca-chimevc-stack
 echo "PACKAGING $dir"
 pushd $dir
-./publish.sh $BUCKET $PREFIX_AND_VERSION/lca-chimevc-stack $REGION || exit 1
+bash ./publish.sh $BUCKET $PREFIX_AND_VERSION/lca-chimevc-stack $REGION || exit 1
 popd
 
 dir=lca-genesys-audiohook-stack

--- a/publish.sh
+++ b/publish.sh
@@ -37,6 +37,9 @@ VERSION=$(cat ./VERSION)
 [[ "${PREFIX}" == */ ]] && PREFIX="${PREFIX%?}"
 PREFIX_AND_VERSION=${PREFIX}/${VERSION}
 
+# Remove invalid character at the end of PREFIX_AND_VERSION
+PREFIX_AND_VERSION=${PREFIX_AND_VERSION::-1} 
+
 # Append region to bucket basename
 BUCKET=${BUCKET_BASENAME}-${REGION}
 


### PR DESCRIPTION
Fix validation error: TemplateURL must be a supported URL

Fix a validation error when calling the ValidateTemplate operation: TemplateURL must be a supported URL.
1. `/amazon-transcribe-live-call-analytics/publish.sh` creates a `PREFIX_AND_VERSION` variable that has an extra character at the end. Remove this empty character fixes the problem (ValidationError) and creates a valid template url at `/amazon-transcribe-live-call-analytics/lca-chimevc-stack/publish.sh` (line 118).
2. Line 66: Under WSL environment was necessary to add the bash key word. Otherwise it throws an error (`Permission denied`).  
3. There are some other files without changes that had an invalid End Of Line Sequence (CRLF) and was not possible to run in a WSL environment. Those are: `/lca-chimevc-stack/publish.sh`, `/lca-ai-stack/deployment/build-s3-dist.sh` & `/lca-genesys-audiohook-stack/deployment/build-s3-dist.sh`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
