### PR TITLE
fix regression issue that prevented persistence of custom metadata js…

### DIFF
--- a/lca-chimevc-stack/lambda_functions/call_transcriber/lca.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/lca.js
@@ -239,6 +239,7 @@ const writeCallStartEventToKds = async function writeCallStartEventToKds(kinesis
     CustomerPhoneNumber: callData.fromNumber,
     SystemPhoneNumber: callData.toNumber,
     AgentId: callData.agentId,
+    Metadatajson: callData.metadatajson,
     EventType: 'START',
   };
   const putParams = {

--- a/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/lca.js
+++ b/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/lca.js
@@ -239,6 +239,7 @@ const writeCallStartEventToKds = async function writeCallStartEventToKds(kinesis
     CustomerPhoneNumber: callData.fromNumber,
     SystemPhoneNumber: callData.toNumber,
     AgentId: callData.agentId,
+    Metadatajson: callData.metadatajson,
     EventType: 'START',
   };
   const putParams = {


### PR DESCRIPTION
fix regression issue that prevented persistence of custom metadata json in DynamoDB call record

*Description of changes:*

Regression in our Lambda Call transcriber.. The function `writeCallStartEventToKds` used to have `Metadatajson` in the START message (see [version here](https://github.com/aws-samples/amazon-transcribe-live-call-analytics/blob/af863c3a4b7d0cd7cc310c984b27875d26d58f8c/lca-chimevc-stack/lambda_functions/call_transcriber/index.js#L190C5-L190C17)) but this was regressed in a commit back in November last year.. The `writeCallStartEventToKds`  function is now in [lca.js](https://github.com/aws-samples/amazon-transcribe-live-call-analytics/blob/main/lca-chimevc-stack/lambda_functions/call_transcriber/lca.js#L234-L242) and is missing the `Metadatajson field`.  Fix is to revert that regression issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
