### PR TITLE
Write two events to TranscriberCallEventTable on CallId modification for ChimeSDK CallAnalytics

### DIFF
--- a/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/index.js
+++ b/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/index.js
@@ -627,11 +627,7 @@ const handler = async function handler(event, context) {
         return;
       }
       
-      let tempCallData = await getCallDataFromChimeEvents(event);
-      callData = await getCallDataFromDdb(tempCallData.callId);
-
-      console.log('Modified callData:');
-      console.log(callData);
+      callData = await getCallDataFromDdb(event.detail.callId);
       await writeCallEndEventToKds(kinesisClient, callData.callId);
       callData.callStreamingEndTime = new Date().toISOString();
       await writeCallDataToDdb(callData, callData.callId);


### PR DESCRIPTION
This PR writes two events to TranscriberCallEventsTable if the LambdaHook modifies the callId, then looks up the call details from dynamodb on call ENDED event. This will allow us to look up the modified callId when we only know the Chime callId for the ENDED event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
