### PR TITLE
feat: boto session read timeout made configurable and increased Trans…

### DIFF
--- a/lca-ai-stack/deployment/lca-ai-stack.yaml
+++ b/lca-ai-stack/deployment/lca-ai-stack.yaml
@@ -1085,7 +1085,8 @@ Resources:
             ]
           ]
           CALL_DATA_STREAM_NAME: !Ref CallDataStream
-      Timeout: 60
+          BOTO_READ_TIMEOUT: 60
+      Timeout: 240
       MemorySize: 128
       Handler: lambda_function.handler
       Layers:

--- a/lca-ai-stack/source/lambda_functions/async_transcript_summary_orchestrator/lambda_function.py
+++ b/lca-ai-stack/source/lambda_functions/async_transcript_summary_orchestrator/lambda_function.py
@@ -31,6 +31,7 @@ else:
 
 BOTO3_SESSION: Boto3Session = boto3.Session()
 CLIENT_CONFIG = BotoCoreConfig(
+    read_timeout= getenv("BOTO_READ_TIMEOUT", 60),
     retries={"mode": "adaptive", "max_attempts": 3},
 )
 


### PR DESCRIPTION
…criptSummary lambda timeout to work retry

*Issue #, if available:*
According to this documentation, https://botocore.amazonaws.com/v1/docs/api/latest/reference/config.html#botocore-config, BotoCoreConfig defaults to 60 seconds because read_timeout is not specified. Max_attempts is set to 3, but lambda timeout has been set to 60 seconds, so retrying actually fails.

*Description of changes:*
Increased lambda timeout allows retry to function with BotoCoreConfig's default read timeout. Additionally, readtimeout for BotoCoreConfig has been changed to be user-configurable in accordance with the latency of the summary lambda/API they are using.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
