### PR TITLE
fix sed command in the case you are deploying this from a mac

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -150,7 +150,16 @@ cp -v ./patches/qnabot/lambda_schema_qna.js $dir/lambda/schema/qna.js
 cp -v ./patches/qnabot/website_js_admin.vue $dir/website/js/admin.vue
 cp -v ./patches/qnabot/Makefile $dir/Makefile
 echo "modify QnABot version string from 'N.N.N' to 'N.N.N-LCA'"
-sed -i 's/"version": *"\([0-9]*\.[0-9]*\.[0-9]*\)"/"version": "\1-LCA"/' $dir/package.json
+
+OS=$(uname -s)
+
+# Detect operating system before running "sed". sed varies betwen linux and mac
+if [ "$OS" == "Darwin" ]; then
+    sed -i '' 's/"version": *"\([0-9]*\.[0-9]*\.[0-9]*\)"/"version": "\1-LCA"/' $dir/package.json
+else
+    sed -i 's/"version": *"\([0-9]*\.[0-9]*\.[0-9]*\)"/"version": "\1-LCA"/' $dir/package.json
+fi
+
 pushd $dir
 rm -fr ./ml_model/llm-qa-summarize # remove deleted folder if left over from previous build.
 mkdir -p build/templates/dev


### PR DESCRIPTION
*Description of changes:*
The "./publish.sh" script works 99% on mac, except that the "sed -i" command differers between mac and linux. 

Added a few lines to detect the operating system, and use the mac version of the command if run from a mac. I verified that the script now works on mac with this small change

I know you may not officially support mac, but since it's so close to working, I hope you will merge this pull request anyway

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
