### PR TITLE
Process redacted transcript and recording for PCA

### DIFF
--- a/lca-chimevc-stack/cloudformation-templates/process-tca-postcall.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/process-tca-postcall.yaml
@@ -37,7 +37,16 @@ Parameters:
 
   IsContentRedactionEnabled:
     Type: String
-    Description: Is Content Redaction enabled 'true' or 'false' 
+    Description: Is Content Redaction enabled 'true' or 'false'
+
+  UsedChimeCallAnalytics:
+    Type: String
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    Description: >
+      Whether Amazon Chime SDK Call Analytics is used, instead the call transcriber Lambda.  
         
 Resources:
   ##########################################################################
@@ -85,6 +94,7 @@ Resources:
           LCA_BUCKET_NAME: !Ref LCAS3BucketName
           CALL_ANALYTICS_FILE_PREFIX: !Ref CallAnalyticsPrefix
           IS_CONTENT_REDACTION_ENABLED: !Ref IsContentRedactionEnabled
+          USED_CHIME_CALL_ANALYTICS: !Ref UsedChimeCallAnalytics
       CodeUri: ../lambda_functions/process_tca_postcall
 
   ProcessTCAPostCallFunctionRole:

--- a/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/index.js
+++ b/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/index.js
@@ -25,7 +25,6 @@ const {
   formatPath,
   writeCallStartEventToKds,
   writeCallEndEventToKds,
-  writeS3UrlToKds,
 } = require('./lca');
 
 const REGION = process.env.REGION || 'us-east-1';
@@ -686,10 +685,6 @@ const handler = async function handler(event, context) {
       return;
     }
 
-    // save recording url to callData in order to send the ADD_S3_RECORDING_URL KDS at the end of the call
-    callData.recordingUrl = event.detail.recordingUrl;
-    await writeCallDataToDdb(callData);
-
     const sessionData = {
       sessionId: event.detail.sessionId,
       callId: callId,
@@ -767,10 +762,6 @@ const handler = async function handler(event, context) {
 
       await writeCallEndEventToKds(kinesisClient, callDataFromDdb.callId);
       await writeCallDataToDdb(callDataFromDdb);
-
-      if (callDataFromDdb.recordingUrl) {
-        await writeS3UrlToKds(kinesisClient, callDataFromDdb.callId, callDataFromDdb.recordingUrl);
-      }
 
       if (callDataFromDdb.mediaPipelineId) {
         // wait 2 seconds to allow media pipeline to process the remaining audio stream

--- a/lca-chimevc-stack/lambda_functions/pca_integration/index.js
+++ b/lca-chimevc-stack/lambda_functions/pca_integration/index.js
@@ -50,7 +50,6 @@ function mkTcaFilename(sessionData) {
   return f;
 }
 
-// TODO - Refactor to use new TCA Post Call event - now includes Transcript file and Media File Uris.
 function getAnalyticsOutputUri(sessionId, suffix) {
   const analyticsfolder = (IS_CONTENT_REDACTION_ENABLED) ? "redacted-analytics/" : "analytics/";
   const uri = `/${LCA_BUCKET_NAME}/${CALL_ANALYTICS_FILE_PREFIX}${analyticsfolder}${sessionId}${suffix}`;
@@ -115,10 +114,18 @@ const getS3PathFromUri = function getS3SourceUri(s3Uri) {
 };
 
 const copyAudioRecordingToPca = async function copyAudioRecordingToPca(s3Client, event, sessionData) {
-  let s3SourcePath;
-  if (event.detail.Media && event.detail.Media.MediaFileUri) {
-    s3SourcePath = encodeURI(getS3PathFromUri(event.detail.Media.MediaFileUri));
+  let s3SourcePath = undefined;
+  if (IS_CONTENT_REDACTION_ENABLED) {
+    if (event.detail.Media && event.detail.Media.RedactedMediaFileUri) {
+      s3SourcePath = encodeURI(getS3PathFromUri(event.detail.Media.RedactedMediaFileUri));
+    }
   } else {
+    if (event.detail.Media && event.detail.Media.MediaFileUri) {
+      s3SourcePath = encodeURI(getS3PathFromUri(event.detail.Media.MediaFileUri));
+    }
+  }
+
+  if (s3SourcePath === undefined) {
     s3SourcePath = encodeURI(getAnalyticsOutputUri(sessionData.sessionId, '.wav'));
   }
 
@@ -137,10 +144,18 @@ const copyAudioRecordingToPca = async function copyAudioRecordingToPca(s3Client,
 };
 
 const copyPostCallAnalyticsToPca = async function copyPostCallAnalyticsToPca(s3Client, event, sessionData) {
-  let s3SourcePath;
-  if (event.detail.Transcript && event.detail.Transcript.TranscriptFileUri) {
-    s3SourcePath = encodeURI(getS3PathFromUri(event.detail.Transcript.TranscriptFileUri));
+  let s3SourcePath = undefined;
+  if (IS_CONTENT_REDACTION_ENABLED) {
+    if (event.detail.Transcript && event.detail.Transcript.RedactedTranscriptFileUri) {
+      s3SourcePath = encodeURI(getS3PathFromUri(event.detail.Transcript.RedactedTranscriptFileUri));
+    }
   } else {
+    if (event.detail.Transcript && event.detail.Transcript.TranscriptFileUri) {
+      s3SourcePath = encodeURI(getS3PathFromUri(event.detail.Transcript.TranscriptFileUri));
+    }
+  }
+
+  if (s3SourcePath === undefined) {
     s3SourcePath = encodeURI(getAnalyticsOutputUri(sessionData.sessionId, '.json'));
   }
 

--- a/lca-chimevc-stack/template.yaml
+++ b/lca-chimevc-stack/template.yaml
@@ -392,6 +392,7 @@ Resources:
           - !GetAtt DeployChimeCallAnalyticsProcessor.Outputs.IsContentRedactionEnabled
         LCAS3BucketName: !Ref S3BucketName
         CallAnalyticsPrefix: !Ref CallAnalyticsPrefix
+        UsedChimeCallAnalytics: !Ref UseChimeCallAnalytics
 
 Outputs:
   DemoPBXIPAddress:


### PR DESCRIPTION
Handle both redacted and non redacted transcript and recording file for
PCA. Moved ADD_S3_RECORDING_URL to when TCA persists the transcript and
recording files into S3.

Test
manually tested redacted and validate that recording url in LCA appears
after TCA persists the S3 files.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
