### PR TITLE
Fix: Prevent START_CALL_PROCESSING if call has already ended. This re…

### DIFF
--- a/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/index.js
+++ b/lca-chimevc-stack/lambda_functions/chime_call_analytics_initialization/index.js
@@ -436,6 +436,10 @@ const getCallDataForStartCallEvent = async function getCallDataForStartCallEvent
     console.log(`ERROR: Call ${callId} is already processed/processing - exiting.`);
     return undefined;
   }
+  if (callData.callStreamingEndTime) {
+    console.log(`ERROR: Call ${callId} has already ended - exiting.`);
+    return undefined;
+  }
   // Add Start Call Event info to saved callData object and write back to DDB for tracing
   callData.startCallProcessingEvent = scpevent;
   callData.callProcessingStartTime = new Date().toISOString();


### PR DESCRIPTION
Fix: Prevent START_CALL_PROCESSING if call has already ended. This removes possibility that START CALL PROCESSING picks up re-purposed KVS streams for a different callId.

*Issue #, if available:*  N/A

*Description of changes:*

Add check for callStreamingEndTime value in callData, written to DynamoDB at end of call. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
