### PR TITLE
Add a logic to determine GNU sed vs BSD sed

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -163,7 +163,12 @@ cp -v ./patches/qnabot/lambda_schema_qna.js $dir/lambda/schema/qna.js
 cp -v ./patches/qnabot/website_js_admin.vue $dir/website/js/admin.vue
 cp -v ./patches/qnabot/Makefile $dir/Makefile
 echo "modify QnABot version string from 'N.N.N' to 'N.N.N-LCA'"
-sed -i 's/"version": *"\([0-9]*\.[0-9]*\.[0-9]*\)"/"version": "\1-LCA"/' $dir/package.json
+# Detection of differences. sed varies betwen GNU sed and BSD sed
+if sed --version 2>/dev/null | grep -q GNU; then # GNU sed
+  sed -i 's/"version": *"\([0-9]*\.[0-9]*\.[0-9]*\)"/"version": "\1-LCA"/' $dir/package.json
+else # BSD like sed
+  sed -i '' 's/"version": *"\([0-9]*\.[0-9]*\.[0-9]*\)"/"version": "\1-LCA"/' $dir/package.json
+fi
 pushd $dir
 rm -fr ./ml_model/llm-qa-summarize # remove deleted folder if left over from previous build.
 mkdir -p build/templates/dev


### PR DESCRIPTION
*Issue #117*

*Description of changes:*

Added logic to "publish.sh" to compare GNU sed and BSD sed.

GNU sed provides version information with the ["--version" option](https://www.gnu.org/software/sed/manual/sed.html#Command_002dLine-Options);
[BSD sed does not support this option](https://man.freebsd.org/cgi/man.cgi?query=sed&apropos=0&sektion=1&manpath=macOS+13.5&arch=default&format=html), so you will get an error message when you run this command.

We may have installed gnu-sed on macOS and used alias sed='gsed'.
Therefore, it is my opinion that the sed command is the preferred way to determine if a system is GNU-based or BSD-based.
I have decided that using the `if [ "$(uname)" == 'Darwin' ]; then` command is not a good idea.

Similar PR #107


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
