### PR TITLE
fix #121 - Changing the LLM_CHAT_HISTORY_MAX_MESSAGES in QnABot cause…

### DIFF
--- a/lca-agentassist-setup-stack/template.yaml
+++ b/lca-agentassist-setup-stack/template.yaml
@@ -264,7 +264,7 @@ Resources:
               return result["transcript"]
 
           def format_response(event, transcript):
-              maxMessages = event["req"]["_settings"].get("LLM_CHAT_HISTORY_MAX_MESSAGES", 20)
+              maxMessages = int(event["req"]["_settings"].get("LLM_CHAT_HISTORY_MAX_MESSAGES", 20))
               print(f"Using last {maxMessages} conversation turns (LLM_CHAT_HISTORY_MAX_MESSAGES)")
               transcriptSegments = transcript.strip().split('\n')
               # remove final segment if it matches the current utterance


### PR DESCRIPTION
Changing the LLM_CHAT_HISTORY_MAX_MESSAGES in QnABot caused error with processing utterances

*Issue #, if available:*
#121 

*Description of changes:*

Added int() cast to ensure string value (result of changing parameter) is converted to integer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
