### PR TITLE
Expanded redaction support (

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To get LCA up and running in your own AWS account, follow these steps (if you do
        **Amazon Transcribe Configuration**
    22. `Enable Partial Transcripts` - Enable partial transcripts to receive low latency evolving transcriptions for each conversation turn.
    23. `Transcribe API mode` - Set the default API mode for Transcribe. Set to 'analytics' to use the Amazon Transcribe Real-time Call Analytics service, used to support call categories and alerts, call summarization, and PCA integration.
-   24. `Enable Content Redaction for Transcripts` - Enable content redaction from Amazon Transcribe transcription output. **NOTE:** Content redaction is only available when using the English language (en-US). This parameter is ignored when not using the English language
+   24. `Enable Content Redaction for Transcripts` - Enable content redaction from Amazon Transcribe transcription output. **NOTE:** Content redaction is only available when using English (en-US, en-GB, en-AU) or Spanish (es-US). This parameter is ignored when not using other languages.
    25. `Language for Transcription` - Language code to be used for Amazon Transcribe
    26. `Content Redaction Type for Transcription` - Type of content redaction from Amazon Transcribe transcription output
    27. `Transcription PII Redaction Entity Types` - Select the PII entity types you want to identify or redact. Remove the values that you don't want to redact from the default. _DO NOT ADD CUSTOM VALUES HERE_.

--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-call-analytics.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-call-analytics.yaml
@@ -67,7 +67,7 @@ Parameters:
     Default: 'false'
     Description: >-
       Enable content redaction from Amazon Transcribe transcription output. This is only used when
-      the 'en-US' language is selected in the TranscribeLanguageCode parameter.
+      the 'en-US', 'en-AU', 'en-GB' or 'es-US' languages are selected in the TranscribeLanguageCode parameter.
     AllowedValues:
       - 'true'
       - 'false'
@@ -954,7 +954,11 @@ Metadata:
 Conditions:
   ShouldEnableContentRedaction: !And
     - !Equals [!Ref IsContentRedactionEnabled, 'true']
-    - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+    - !Or 
+      - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-AU']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-GB']
+      - !Equals [!Ref TranscribeLanguageCode, 'es-US']
   ShouldEnableLambdaHook: !Not [!Equals [!Ref SiprecLambdaHookFunctionArn, '']]
   ShouldUseCreatedVoiceConnector: !Equals [!Ref CustomVoiceConnectorId, '']
 

--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-call-transcriber.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-call-transcriber.yaml
@@ -53,7 +53,7 @@ Parameters:
     Default: 'false'
     Description: >-
       Enable content redaction from Amazon Transcribe transcription output. This is only used when
-      the 'en-US' language is selected in the TranscribeLanguageCode parameter.
+      the 'en-US', 'en-AU', 'en-GB' or 'es-US' languages are selected in the TranscribeLanguageCode parameter.
     AllowedValues:
       - 'true'
       - 'false'
@@ -437,7 +437,11 @@ Metadata:
 Conditions:
   ShouldEnableContentRedaction: !And
     - !Equals [!Ref IsContentRedactionEnabled, 'true']
-    - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+    - !Or 
+      - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-AU']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-GB']
+      - !Equals [!Ref TranscribeLanguageCode, 'es-US']
   ShouldEnableLambdaHook: !Not [!Equals [!Ref SiprecLambdaHookFunctionArn, '']]
 
 Outputs:

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -648,7 +648,11 @@ const go = async function go(callData) {
   if (sessionId !== undefined) {
     tsParams.SessionId = sessionId;
   }
-  if (IS_CONTENT_REDACTION_ENABLED && TRANSCRIBE_LANGUAGE_CODE === 'en-US') {
+  if (IS_CONTENT_REDACTION_ENABLED && (
+    TRANSCRIBE_LANGUAGE_CODE === 'en-US' ||
+    TRANSCRIBE_LANGUAGE_CODE === 'en-AU' ||
+    TRANSCRIBE_LANGUAGE_CODE === 'en-GB' ||
+    TRANSCRIBE_LANGUAGE_CODE === 'es-US')) {
     tsParams.ContentRedactionType = CONTENT_REDACTION_TYPE;
     if (PII_ENTITY_TYPES) tsParams.PiiEntityTypes = PII_ENTITY_TYPES;
   }

--- a/lca-chimevc-stack/template.yaml
+++ b/lca-chimevc-stack/template.yaml
@@ -134,7 +134,7 @@ Parameters:
     Default: 'false'
     Description: >-
       Enable content redaction from Amazon Transcribe transcription output. This is only used when
-      the 'en-US' language is selected in the TranscribeLanguageCode parameter.
+      the 'en-US', 'en-AU', 'en-GB' or 'es-US' languages are selected in the TranscribeLanguageCode parameter.
     AllowedValues:
       - 'true'
       - 'false'

--- a/lca-connect-kvs-stack/lambda_functions/connect_kvs_consumer/index.js
+++ b/lca-connect-kvs-stack/lambda_functions/connect_kvs_consumer/index.js
@@ -488,7 +488,11 @@ const go = async function go(callData) {
   if (sessionId !== undefined) {
     tsParams.SessionId = sessionId;
   }
-  if (IS_CONTENT_REDACTION_ENABLED && TRANSCRIBE_LANGUAGE_CODE === 'en-US') {
+  if (IS_CONTENT_REDACTION_ENABLED && (
+    TRANSCRIBE_LANGUAGE_CODE === 'en-US' ||
+    TRANSCRIBE_LANGUAGE_CODE === 'en-AU' ||
+    TRANSCRIBE_LANGUAGE_CODE === 'en-GB' ||
+    TRANSCRIBE_LANGUAGE_CODE === 'es-US')) {
     tsParams.ContentRedactionType = CONTENT_REDACTION_TYPE;
     if (PII_ENTITY_TYPES) tsParams.PiiEntityTypes = PII_ENTITY_TYPES;
   }

--- a/lca-connect-kvs-stack/template.yaml
+++ b/lca-connect-kvs-stack/template.yaml
@@ -67,7 +67,7 @@ Parameters:
     Default: 'false'
     Description: >-
       Enable content redaction from Amazon Transcribe transcription output. This is only used when
-      the 'en-US' language is selected in the TranscribeLanguageCode parameter.
+      the 'en-US', 'en-AU', 'en-GB' or 'es-US' languages are selected in the TranscribeLanguageCode parameter.
     AllowedValues:
       - 'true'
       - 'false'
@@ -564,7 +564,11 @@ Metadata:
 Conditions:
   ShouldEnableContentRedaction: !And
     - !Equals [!Ref IsContentRedactionEnabled, 'true']
-    - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+    - !Or 
+      - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-AU']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-GB']
+      - !Equals [!Ref TranscribeLanguageCode, 'es-US']
 
 Outputs:
 

--- a/lca-genesys-audiohook-stack/deployment/genesys-audiohook.yaml
+++ b/lca-genesys-audiohook-stack/deployment/genesys-audiohook.yaml
@@ -74,7 +74,7 @@ Parameters:
     Default: "false"
     Description: >-
       Enable content redaction from Amazon Transcribe transcription output. This is only used when
-      the 'en-US' language is selected in the TranscribeLanguageCode parameter.
+      the 'en-US', 'en-AU', 'en-GB' or 'es-US' languages are selected in the TranscribeLanguageCode parameter.
     AllowedValues:
       - "true"
       - "false"
@@ -212,7 +212,11 @@ Metadata:
 Conditions:
   ShouldEnableContentRedaction: !And
     - !Equals [!Ref IsContentRedactionEnabled, 'true']
-    - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+    - !Or 
+      - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-AU']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-GB']
+      - !Equals [!Ref TranscribeLanguageCode, 'es-US']
   ShouldInstallPcaIntegration: !Not [!Equals [!Ref PcaS3BucketName, '']]
 
 Outputs:

--- a/lca-genesys-audiohook-stack/source/app/src/stream-to-lca.ts
+++ b/lca-genesys-audiohook-stack/source/app/src/stream-to-lca.ts
@@ -151,7 +151,11 @@ export const addStreamToLCA = (session: Session) => {
             AudioStream: transcribeInput()
         };
         
-        if (IS_CONTENT_REDACTION_ENABLED && TRANSCRIBE_LANGUAGE_CODE === 'en-US') {
+        if (IS_CONTENT_REDACTION_ENABLED && (
+            TRANSCRIBE_LANGUAGE_CODE === 'en-US' ||
+            TRANSCRIBE_LANGUAGE_CODE === 'en-AU' ||
+            TRANSCRIBE_LANGUAGE_CODE === 'en-GB' ||
+            TRANSCRIBE_LANGUAGE_CODE === 'es-US')) {
             tsParams.ContentRedactionType = CONTENT_REDACTION_TYPE;
             if (TRANSCRIBE_PII_ENTITY_TYPES) {
                 tsParams.PiiEntityTypes = TRANSCRIBE_PII_ENTITY_TYPES;

--- a/lca-main.yaml
+++ b/lca-main.yaml
@@ -278,7 +278,7 @@ Parameters:
     Default: 'false'
     Description: >-
       Enable content redaction from Amazon Transcribe transcription output. This is only used when
-      the 'en-US' language is selected in the TranscribeLanguageCode parameter.
+      the 'en-US', 'en-AU', 'en-GB' or 'es-US' languages are selected in the TranscribeLanguageCode parameter.
     AllowedValues:
       - 'true'
       - 'false'

--- a/lca-websocket-stack/deployment/lca-websocket.yaml
+++ b/lca-websocket-stack/deployment/lca-websocket.yaml
@@ -78,7 +78,7 @@ Parameters:
     Default: "false"
     Description: >-
       Enable content redaction from Amazon Transcribe transcription output. This is only used when
-      the 'en-US' language is selected in the TranscribeLanguageCode parameter.
+      the 'en-US', 'en-AU', 'en-GB' or 'es-US' languages are selected in the TranscribeLanguageCode parameter.
     AllowedValues:
       - "true"
       - "false"
@@ -220,7 +220,11 @@ Metadata:
 Conditions:
   ShouldEnableContentRedaction: !And
     - !Equals [!Ref IsContentRedactionEnabled, 'true']
-    - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+    - !Or 
+      - !Equals [!Ref TranscribeLanguageCode, 'en-US']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-AU']
+      - !Equals [!Ref TranscribeLanguageCode, 'en-GB']
+      - !Equals [!Ref TranscribeLanguageCode, 'es-US']
   ShouldInstallPcaIntegration: !Not [!Equals [!Ref PcaS3BucketName, '']]
 
 Outputs:

--- a/lca-websocket-stack/source/app/src/lca.ts
+++ b/lca-websocket-stack/source/app/src/lca.ts
@@ -294,7 +294,11 @@ export const startTranscribe = async (callMetaData: CallMetaData, audioInputStre
         AudioStream: transcribeInput()
     };
     
-    if (IS_CONTENT_REDACTION_ENABLED && TRANSCRIBE_LANGUAGE_CODE === 'en-US') {
+    if (IS_CONTENT_REDACTION_ENABLED && (
+        TRANSCRIBE_LANGUAGE_CODE === 'en-US' ||
+        TRANSCRIBE_LANGUAGE_CODE === 'en-AU' ||
+        TRANSCRIBE_LANGUAGE_CODE === 'en-GB' ||
+        TRANSCRIBE_LANGUAGE_CODE === 'es-US')) {
         tsParams.ContentRedactionType = CONTENT_REDACTION_TYPE as ContentRedactionType;
         if (TRANSCRIBE_PII_ENTITY_TYPES) {
             tsParams.PiiEntityTypes = TRANSCRIBE_PII_ENTITY_TYPES;


### PR DESCRIPTION
*Description of changes:*

Expanded redaction support to include all languages (and dialects) on the [Amazon Transcribe supported languages page](https://docs.aws.amazon.com/transcribe/latest/dg/supported-languages.html).

I tested the WebSocket Server and Lambda Call Transcriber with US Spanish (es-US) and GB English (es-GB), and see successful redaction. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
