### PR TITLE
Fix/stream and call end refactor

### DIFF
--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -587,7 +587,7 @@ const readKVS = async (streamName, streamArn, lastFragment, streamPipe, callData
           fragmentCallId = chunk.Children[1].data;
 
           if (callData.originalCallId !== fragmentCallId) {
-            console.log(`Error: ${streamName}'s MKV data has a CallId of ${fragmentCallId}, expecting ${originalCallId} `);
+            console.log(`Error: ${streamName}'s MKV data has a CallId of ${fragmentCallId}, expecting ${callData.originalCallId} `);
             
             (async () => {
               // write is call ended. Since these are async, calling them from within an anonymous promise

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -417,7 +417,7 @@ const getCallDataWithOriginalCallIdFromDdb = async function getCallDataWithOrigi
   try {
     const data = await dynamoClient.send(command);
     console.log('GetItem result: ', JSON.stringify(data));
-    callData = getCallDataFromDdb(data.Item.CallId.S);
+    callData = getCallDataFromDdb(data.Item.CallId.S);  #TODO Invalid key if mapping not found..
   } catch (error) {
     console.log('Error retrieving callData - Possibly invalid callId?: ', error);
   }
@@ -463,8 +463,7 @@ const getCallDataFromDdb = async function getCallDataFromDdb(callId) {
 
 const getCallDataForStartCallEvent = async function getCallDataForStartCallEvent(scpevent) {
   const { callId } = scpevent;
-  // START_CALL_PROCESSING event uses the original callId. Use originalCallId to get the callData.
-  const callData = await getCallDataWithOriginalCallIdFromDdb(callId);
+  const callData = await getCallDataFromDdb(callId);
   if (!callData) {
     console.log(`ERROR: No callData stored for callId: ${callId} - exiting.`);
     return undefined;
@@ -517,7 +516,7 @@ function timestampDeltaCheck(n) {
 
 const checkIfCallEnded = async (callId) => {
   console.log('Checking if call has ended.');
-  const latestCallData = await getCallDataWithOriginalCallIdFromDdb(callId);
+  const latestCallData = await getCallDataFromDdb(callId);
   if (latestCallData.callStreamingStatus === 'ENDED') {
     console.log(`CallData has been updated to set callStreamingStatus to ENDED. Stop call processing for ${callId}`)
     isCallEnded = true;

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -417,7 +417,7 @@ const getCallDataWithOriginalCallIdFromDdb = async function getCallDataWithOrigi
   try {
     const data = await dynamoClient.send(command);
     console.log('GetItem result: ', JSON.stringify(data));
-    callData = getCallDataFromDdb(data.Item.CallId.S);  #TODO Invalid key if mapping not found..
+    callData = getCallDataFromDdb(data.Item.CallId.S);
   } catch (error) {
     console.log('Error retrieving callData - Possibly invalid callId?: ', error);
   }

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -670,7 +670,12 @@ const readKVS = async (streamName, streamArn, lastFragment, streamPipe, original
         await sleep(1000);
         streamReader = await getKVSstreamReader(streamArn, lastFragment);
       } else {
-        console.log(`${streamName} detected call ended, exiting KVS stream reading.`);
+        if (isCallEnded) {
+          console.log(`${streamName} detected call ended, exiting KVS stream reading.`);
+        }
+        if (timeToStop) {
+          console.log(`${streamName} detected time to invoke new lambda, exiting KVS stream reading.`);
+        }
         break;
       }
     }

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -943,6 +943,7 @@ const handler = async function handler(event, context) {
   if (callStatusCheckTimer) {
     console.log('Clearing previous callStatusCheckTimer');
     clearInterval(callStatusCheckTimer); 
+    callStatusCheckTimer = undefined;
   }
 
   /*

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -1010,12 +1010,6 @@ const handler = async function handler(event, context) {
       callDataFromDdb.callStreamingStatus = 'ENDED';
       callDataFromDdb.callStreamingEndTime = new Date().toISOString();
       await writeCallDataToDdb(callDataFromDdb);
-
-      if (callDataFromDdb.mediaPipelineId) {
-        // wait 2 seconds to allow media pipeline to process the remaining audio stream
-        await sleep(2000);
-        await StopChimeCallAnalyticsMediaPipeline(chimeMediaPipelinesClient, callDataFromDdb.mediaPipelineId);
-      }
     } else {
       console.log(
         `AWS Chime stream status ${event.detail.streamingStatus}: Nothing to do - exiting`,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1)  Refactor call end handling, to explicitly process ENDED messages from VoiceConnector, rather than imputing call end from stream data ending - adds robustness when stream can end (temporarily) for other reasons (such as call hold, etc.)	
2)  Added the callId to the log output, so that it is easier to trace calls.
3) Added the request id of the next Lambda invocation in the output of the log, so that it makes it easier to trace sequential lambda invocations (chaining).
4) Identified a situation where if a call chained across multiple lambda invocations (lasted longer than 12 minutes),  the new timer we introduced that checks if the call ends would leak into the next lambda invocation. This is why in the logs we saw multiple sequential DynamoDB checks. This would have no effect for a single long running call other than duplicate checks to DynamoDB—however—if the call ends and a NEW call uses that warm Lambda, the new call would inherit the timers and within 5 seconds mark the call as ended.  To fix this, we made modifications by adding proper clean-up of timers when the call ends, and also double checking when the next call begins that the new Lambda did not inherit any calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
