### PR TITLE
reduce stack dependencies by created shared resources - VPC, bucket, KDS stream, settings parameter in main stack

### DIFF
--- a/lca-main.yaml
+++ b/lca-main.yaml
@@ -1197,9 +1197,7 @@ Resources:
                 reason = f"Exception thrown: {e}"
                 status = cfnresponse.FAILED              
             cfnresponse.send(event, context, status, responseData, reason=reason)
-      LoggingConfig:
-        LogGroup:
-          Ref: UpdateLCASettingsFunctionLogGroup
+
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -1209,13 +1207,6 @@ Resources:
             reason: Customer can choose reserved concurrency based on their requirement.
           - id: W58
             reason: Managed policy already provides access to CloudWatch logs.
-
-  UpdateLCASettingsFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName:
-        Fn::Sub: /${AWS::StackName}/lambda/UpdateLCASettingsFunction
-      RetentionInDays: 14
 
   UpdateLCASettingsWithInitialValues:
     Type: AWS::CloudFormation::CustomResource


### PR DESCRIPTION
Updates to PR #160 
- create shared VPC in separate nested stack. 
- reduce stack dependencies by created shared resources - bucket, KDS stream, settings parameter in main stack
- improvements in publish.sh script to avoid rebuilding unchanged nested components
- Enable Websocket transcriber by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
