### PR TITLE
Feature/lang override in lambdahook

### DIFF
--- a/lca-ai-stack/source/ui/src/components/common/summary.js
+++ b/lca-ai-stack/source/ui/src/components/common/summary.js
@@ -8,8 +8,15 @@ export const getTextOnlySummary = (callSummaryText) => {
   let summary = callSummaryText;
   try {
     const jsonObj = JSON.parse(summary);
-    if ('summary' in jsonObj) summary = jsonObj.summary;
-    else if ('Summary' in jsonObj) summary = jsonObj.Summary;
+    // Do a case-insensitive search for 'summary' in the JSON object keys
+    const summaryKey = Object.keys(jsonObj).find((key) => key.toLowerCase() === 'summary');
+    if (summaryKey !== undefined) {
+      summary = jsonObj[summaryKey];
+    } else if (Object.keys(jsonObj).length > 0) {
+      // If 'summary' is not found, use the first key as the summary
+      summary = Object.keys(jsonObj)[0] || '';
+      summary = jsonObj[summary];
+    }
   } catch (e) {
     return callSummaryText;
   }

--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-call-transcriber.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-call-transcriber.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 
 Description: Amazon Transcribe Live Call Analytics with Agent Assist - Amazon Chime SDK Voice Connector Call Transcriber Lambda
@@ -40,23 +40,23 @@ Parameters:
 
   IsPartialTranscriptEnabled:
     Type: String
-    Default: 'true'
+    Default: "true"
     Description: >-
       Enable partial transcripts to receive low latency evolving transcriptions for each conversation turn. Set to false to process only the
       final version of each conversation turn.
     AllowedValues:
-      - 'true'
-      - 'false'
+      - "true"
+      - "false"
 
   IsContentRedactionEnabled:
     Type: String
-    Default: 'false'
+    Default: "false"
     Description: >-
       Enable content redaction from Amazon Transcribe transcription output. This is only used when
       the 'en-US', 'en-AU', 'en-GB' or 'es-US' languages are selected in the TranscribeLanguageCode parameter.
     AllowedValues:
-      - 'true'
-      - 'false'
+      - "true"
+      - "false"
 
   TranscribeContentRedactionType:
     Type: String
@@ -73,26 +73,26 @@ Parameters:
       language identification can't  be combined with custom language models or redaction.
     Default: en-US
     AllowedValues:
-    - identify-language
-    - identify-multiple-languages
-    - en-US
-    - es-US
-    - en-GB
-    - fr-CA
-    - fr-FR
-    - en-AU
-    - it-IT
-    - de-DE
-    - pt-BR
-    - ja-JP
-    - ko-KR
-    - zh-CN
-    - hi-IN
-    - th-TH
+      - identify-language
+      - identify-multiple-languages
+      - en-US
+      - es-US
+      - en-GB
+      - fr-CA
+      - fr-FR
+      - en-AU
+      - it-IT
+      - de-DE
+      - pt-BR
+      - ja-JP
+      - ko-KR
+      - zh-CN
+      - hi-IN
+      - th-TH
 
   TranscribeLanguageOptions:
     Type: String
-    Default: 'en-US, es-US'
+    Default: "en-US, es-US"
     AllowedPattern: '^(?:\s*(?:en-US|es-US|en-GB|fr-CA|fr-FR|en-AU|it-IT|de-DE|pt-BR|ja-JP|ko-KR|zh-CN|hi-IN|th-TH)\s*(?:,\s*(?:en-US|es-US|en-GB|fr-CA|fr-FR|en-AU|it-IT|de-DE|pt-BR|ja-JP|ko-KR|zh-CN|hi-IN|th-TH)\s*)*)?$'
     ConstraintDescription: >-
       Unsupported language code. Allowed values are: en-US, es-US, en-GB, fr-CA, fr-FR,
@@ -123,23 +123,29 @@ Parameters:
 
   CustomVocabularyName:
     Type: String
-    Default: ''
+    Default: ""
     Description: >-
       The name of the vocabulary to use when processing the transcription job. Leave blank if no
       custom vocabulary to be used. If yes, the custom vocabulary must pre-exist in your account.
+      Specify multiple custom vocabularies by separating them with a comma (,) and appending language 
+      code after each vocabulary name as '_<langcode>', e.g. 'MyVocab_en-US,MyVocab_es-US' to support using custom 
+      vocabularies for different languages set by a custom call initialization Lambda Hook.
 
   CustomLanguageModelName:
     Type: String
-    Default: ''
+    Default: ""
     Description: >-
       The name of the custom language model to use when processing the transcription job. Leave blank if no
       custom language model is to be used. If specified, the custom language model must pre-exist in your account, 
       match the Language Code selected above, and use the 'Narrow Band' base model.
+      Specify multiple custom language models by separating them with a comma (,) and appending language 
+      code after each language model name as '_<langcode>', e.g. 'MyCLM_en-US, MyCLM_es-US' to support using custom 
+      language models for different languages set by a custom call initialization Lambda Hook.
 
   SiprecLambdaHookFunctionArn:
-    Default: ''
+    Default: ""
     Type: String
-    AllowedPattern: '^(|arn:aws:lambda:.*)$'
+    AllowedPattern: "^(|arn:aws:lambda:.*)$"
     Description: >
       (Optional) Used only when CallAudioSource is set to 'Chime Voice Connector (SIPREC)'.
       If present, the specified Lambda function is invoked at the start of each call. 
@@ -149,7 +155,7 @@ Parameters:
 
   VoiceConnectorId:
     Type: String
-    Default: ''
+    Default: ""
     Description: >-
       Voice connector Id for setting up EventBridge Rule to restrict events to specific Amazon Chime SDK Voice Connector.
 
@@ -213,7 +219,7 @@ Resources:
       Layers:
         # periodically update the Lambda Insights Layer
         # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versions.html
-        - !Sub 'arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension-Arm64:2'
+        - !Sub "arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension-Arm64:2"
         - !Ref TranscriberLambdaLayer
       Role: !GetAtt CallTranscriberFunctionRole.Arn
       Runtime: nodejs18.x
@@ -223,23 +229,23 @@ Resources:
       Environment:
         Variables:
           TRANSCRIBE_API_MODE: !Ref TranscribeApiMode
-          BUFFER_SIZE: '3200'
-          LAMBDA_INVOKE_TIMEOUT: '720000'
+          BUFFER_SIZE: "3200"
+          LAMBDA_INVOKE_TIMEOUT: "720000"
           KINESIS_STREAM_NAME: !Ref KinesisDataStreamName
           TRANSCRIBER_CALL_EVENT_TABLE_NAME: !Ref TranscriberCallEventTable
           REGION: !Ref AWS::Region
           OUTPUT_BUCKET: !Ref S3BucketName
-          RAW_FILE_PREFIX: 'lca-audio-raw/'
+          RAW_FILE_PREFIX: "lca-audio-raw/"
           RECORDING_FILE_PREFIX: !Ref AudioFilePrefix
           CALL_ANALYTICS_FILE_PREFIX: !Ref CallAnalyticsPrefix
           TCA_DATA_ACCESS_ROLE_ARN: !GetAtt TcaDataAccessRole.Arn
-          POST_CALL_CONTENT_REDACTION_OUTPUT: 'redacted'
-          TEMP_FILE_PATH: '/tmp/'
+          POST_CALL_CONTENT_REDACTION_OUTPUT: "redacted"
+          TEMP_FILE_PATH: "/tmp/"
           SAVE_PARTIAL_TRANSCRIPTS: !Ref IsPartialTranscriptEnabled
           IS_CONTENT_REDACTION_ENABLED: !If
             - ShouldEnableContentRedaction
-            - 'true'
-            - 'false'
+            - "true"
+            - "false"
           TRANSCRIBE_LANGUAGE_CODE: !Ref TranscribeLanguageCode
           TRANSCRIBE_LANGUAGE_OPTIONS: !Ref TranscribeLanguageOptions
           TRANSCRIBE_PREFERRED_LANGUAGE: !Ref TranscribePreferredLanguage
@@ -292,13 +298,13 @@ Resources:
                   - transcribe:StartStreamTranscription
                   - transcribe:StartCallAnalyticsStreamTranscription
                   - transcribe:StartTranscriptionJob
-                Resource: '*'
+                Resource: "*"
               - Action:
-                  - 'kinesisvideo:Describe*'
-                  - 'kinesisvideo:Get*'
-                  - 'kinesisvideo:List*'
-                Effect: 'Allow'
-                Resource: '*'
+                  - "kinesisvideo:Describe*"
+                  - "kinesisvideo:Get*"
+                  - "kinesisvideo:List*"
+                Effect: "Allow"
+                Resource: "*"
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
@@ -329,17 +335,17 @@ Resources:
                   - s3:DeleteObject
                 Resource:
                   - !Sub
-                    - 'arn:aws:s3:::${bucket}'
+                    - "arn:aws:s3:::${bucket}"
                     - bucket: !Ref S3BucketName
                   - !Sub
-                    - 'arn:aws:s3:::${bucket}/*'
+                    - "arn:aws:s3:::${bucket}/*"
                     - bucket: !Ref S3BucketName
               - !If
                 - ShouldEnableLambdaHook
                 - Effect: Allow
                   Action:
                     - lambda:InvokeFunction
-                  Resource: !Sub '${SiprecLambdaHookFunctionArn}'
+                  Resource: !Sub "${SiprecLambdaHookFunctionArn}"
                 - Ref: AWS::NoValue
 
   TcaDataAccessRole:
@@ -368,10 +374,10 @@ Resources:
                   - s3:DeleteObject
                 Resource:
                   - !Sub
-                    - 'arn:aws:s3:::${bucket}'
+                    - "arn:aws:s3:::${bucket}"
                     - bucket: !Ref S3BucketName
                   - !Sub
-                    - 'arn:aws:s3:::${bucket}/*'
+                    - "arn:aws:s3:::${bucket}/*"
                     - bucket: !Ref S3BucketName
 
     Metadata:
@@ -382,10 +388,10 @@ Resources:
               Transcribe does not support resource-level permissions and KVS streams are dynamic
 
   AllowEventBridgeToCallTranscriberFunctionLambdaFromChimeVC:
-    Type: 'AWS::Lambda::Permission'
+    Type: "AWS::Lambda::Permission"
     Properties:
       FunctionName: !Ref CallTranscriberFunction
-      Action: 'lambda:InvokeFunction'
+      Action: "lambda:InvokeFunction"
       Principal: events.amazonaws.com
       SourceArn: !GetAtt EventBridgeRuleToTriggerCallTranscriberLambdaFromChimeVC.Arn
       SourceAccount: !Ref AWS::AccountId
@@ -393,25 +399,25 @@ Resources:
   EventBridgeRuleToTriggerCallTranscriberLambdaFromChimeVC:
     Type: AWS::Events::Rule
     Properties:
-      Description: 'This rule is triggered when the ChimeVC streaming status changes'
+      Description: "This rule is triggered when the ChimeVC streaming status changes"
       EventPattern:
         detail:
           voiceConnectorId:
             - !Ref VoiceConnectorId
         detail-type:
-          - 'Chime VoiceConnector Streaming Status'
+          - "Chime VoiceConnector Streaming Status"
         source:
           - aws.chime
       Targets:
         - Id: CallTranscriberTarget
           Arn: !GetAtt CallTranscriberFunction.Arn
-      State: 'ENABLED'
+      State: "ENABLED"
 
   AllowEventBridgeToCallTranscriberFunctionLambdFromIVR:
-    Type: 'AWS::Lambda::Permission'
+    Type: "AWS::Lambda::Permission"
     Properties:
       FunctionName: !Ref CallTranscriberFunction
-      Action: 'lambda:InvokeFunction'
+      Action: "lambda:InvokeFunction"
       Principal: events.amazonaws.com
       SourceArn: !GetAtt EventBridgeRuleToTriggerCallTranscriberLambdaFromIVR.Arn
       SourceAccount: !Ref AWS::AccountId
@@ -419,16 +425,16 @@ Resources:
   EventBridgeRuleToTriggerCallTranscriberLambdaFromIVR:
     Type: AWS::Events::Rule
     Properties:
-      Description: 'This rule is triggered  when a START_CALL_PROCESSING event is sent from IVR'
+      Description: "This rule is triggered  when a START_CALL_PROCESSING event is sent from IVR"
       EventPattern:
         detail-type:
-          - 'START_CALL_PROCESSING'
+          - "START_CALL_PROCESSING"
         source:
           - lca-solution
       Targets:
         - Id: CallTranscriberTarget
           Arn: !GetAtt CallTranscriberFunction.Arn
-      State: 'ENABLED'
+      State: "ENABLED"
 
   # Permission for Call Transcriber to invoke itself
   CallTranscriberPermission:
@@ -439,7 +445,7 @@ Resources:
       Principal: !GetAtt CallTranscriberFunctionRole.Arn
 
 Metadata:
-  'AWS::CloudFormation::Interface':
+  "AWS::CloudFormation::Interface":
     ParameterGroups:
       - Label:
           default: Amazon S3 Configuration
@@ -465,13 +471,13 @@ Metadata:
 
 Conditions:
   ShouldEnableContentRedaction: !And
-    - !Equals [!Ref IsContentRedactionEnabled, 'true']
-    - !Or 
-      - !Equals [!Ref TranscribeLanguageCode, 'en-US']
-      - !Equals [!Ref TranscribeLanguageCode, 'en-AU']
-      - !Equals [!Ref TranscribeLanguageCode, 'en-GB']
-      - !Equals [!Ref TranscribeLanguageCode, 'es-US']
-  ShouldEnableLambdaHook: !Not [!Equals [!Ref SiprecLambdaHookFunctionArn, '']]
+    - !Equals [!Ref IsContentRedactionEnabled, "true"]
+    - !Or
+      - !Equals [!Ref TranscribeLanguageCode, "en-US"]
+      - !Equals [!Ref TranscribeLanguageCode, "en-AU"]
+      - !Equals [!Ref TranscribeLanguageCode, "en-GB"]
+      - !Equals [!Ref TranscribeLanguageCode, "es-US"]
+  ShouldEnableLambdaHook: !Not [!Equals [!Ref SiprecLambdaHookFunctionArn, ""]]
 
 Outputs:
   CallTranscriberEventTableName:
@@ -483,5 +489,5 @@ Outputs:
   IsContentRedactionEnabled:
     Value: !If
       - ShouldEnableContentRedaction
-      - 'true'
-      - 'false'
+      - "true"
+      - "false"

--- a/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
+++ b/lca-chimevc-stack/lambda_functions/call_transcriber/index.js
@@ -60,8 +60,8 @@ const TRANSCRIBE_LANGUAGE_OPTIONS = process.env['TRANSCRIBE_LANGUAGE_OPTIONS'] |
 const TRANSCRIBE_PREFERRED_LANGUAGE = process.env['TRANSCRIBE_PREFERRED_LANGUAGE'] || 'None';
 const CONTENT_REDACTION_TYPE = process.env.CONTENT_REDACTION_TYPE || 'PII';
 const PII_ENTITY_TYPES = process.env.PII_ENTITY_TYPES || 'ALL';
-const CUSTOM_VOCABULARY_NAME = process.env.CUSTOM_VOCABULARY_NAME || '';
-const CUSTOM_LANGUAGE_MODEL_NAME = process.env.CUSTOM_LANGUAGE_MODEL_NAME || '';
+const CUSTOM_VOCABULARY_NAMES = process.env.CUSTOM_VOCABULARY_NAME || '';
+const CUSTOM_LANGUAGE_MODEL_NAMES = process.env.CUSTOM_LANGUAGE_MODEL_NAME || '';
 const KEEP_ALIVE = process.env.KEEP_ALIVE || '10000';
 const LAMBDA_HOOK_FUNCTION_ARN = process.env.LAMBDA_HOOK_FUNCTION_ARN || '';
 const TRANSCRIBE_API_MODE = process.env.TRANSCRIBE_API_MODE || 'standard';
@@ -202,6 +202,7 @@ const getCallDataFromChimeEvents = async function getCallDataFromChimeEvents(cal
     toNumber: callEvent.detail.toNumber,
     agentId: callEvent.detail.agentId,
     metadatajson: undefined,
+    transcribeLanguageCode: TRANSCRIBE_LANGUAGE_CODE,
     callerStreamArn,
     agentStreamArn,
     lambdaCount: 0,
@@ -237,7 +238,8 @@ const getCallDataFromChimeEvents = async function getCallDataFromChimeEvents(cal
           fromNumber: <string>,
           toNumber: <string>,
           shouldRecordCall: <boolean>,
-          metadatajson: <string>
+          metadatajson: <string>,
+          transcribeLanguageCode: <string>
         }
     */
 
@@ -279,6 +281,12 @@ const getCallDataFromChimeEvents = async function getCallDataFromChimeEvents(cal
     if (payload.metadatajson) {
       console.log(`Lambda hook returned metadatajson: "${payload.metadatajson}"`);
       callData.metadatajson = payload.metadatajson;
+    }
+
+    // Transcribe language code?
+    if (payload.transcribeLanguageCode) {
+      console.log(`Lambda hook returned transcribeLanguageCode: "${payload.transcribeLanguageCode}"`);
+      callData.transcribeLanguageCode = payload.transcribeLanguageCode;
     }
 
     // Should we process this call?
@@ -717,6 +725,40 @@ const readTranscripts = async function readTranscripts(tsStream, callId, session
   }
 };
 
+
+/*
+Function to get the correct Custom Vocabulary or Custom Language Model name. 
+The function first splits the CUSTOM_VOCABULARY_NAMES or CUSTOM_LANGUAGE_MODEL_NAMES into an array.
+It then checks for names with the correct language code suffix.
+If there are multiple matches with the suffix, it returns the first match.
+If no matches are found with the suffix, it checks for names without any language code suffix.
+If there are multiple names without suffixes, it returns the first one.
+If no matches are found in both cases, it returns null.
+*/
+function getCustomVocabName(languageCode) {
+  return getNameByLanguageCode(CUSTOM_VOCABULARY_NAMES, languageCode);
+}
+
+function getCustomLanguageModelName(languageCode) {
+  return getNameByLanguageCode(CUSTOM_LANGUAGE_MODEL_NAMES, languageCode);
+}
+
+function getNameByLanguageCode(names, languageCode) {
+  const nameList = names.split(',').map(name => name.trim());
+  // Check for names with the correct language code suffix
+  const matchingSuffix = nameList.filter(name => name.endsWith(`_${languageCode}`));
+  if (matchingSuffix.length > 0) {
+    return matchingSuffix[0];
+  }
+  // Check for names without any language code suffix
+  const noSuffix = nameList.filter(name => !name.includes('_'));
+  if (noSuffix.length > 0) {
+    return noSuffix[0];
+  }
+  return null;
+}
+
+
 const go = async function go(callData) {
   const {
     callId,
@@ -729,7 +771,8 @@ const go = async function go(callData) {
     lastCallerFragment,
     tcaOutputLocation,
     lambdaCount,
-    originalCallId
+    originalCallId,
+    transcribeLanguageCode
   } = callData;
   let sessionId = callData.sessionId;
   let firstChunkToTranscribe = true;
@@ -795,7 +838,7 @@ const go = async function go(callData) {
     tsParams.EnableChannelIdentification = true;
   }
 
-  if (TRANSCRIBE_LANGUAGE_CODE === 'identify-language') {
+  if (transcribeLanguageCode === 'identify-language') {
     tsParams.IdentifyLanguage = true;
     if (TRANSCRIBE_LANGUAGE_OPTIONS) {
       tsParams.LanguageOptions = TRANSCRIBE_LANGUAGE_OPTIONS.replace(/\s/g, '');
@@ -803,7 +846,7 @@ const go = async function go(callData) {
         tsParams.PreferredLanguage = TRANSCRIBE_PREFERRED_LANGUAGE;
       }
     }
-  } else if (TRANSCRIBE_LANGUAGE_CODE === 'identify-multiple-languages') {
+  } else if (transcribeLanguageCode === 'identify-multiple-languages') {
     tsParams.IdentifyMultipleLanguages = true;
     if (TRANSCRIBE_LANGUAGE_OPTIONS) {
       tsParams.LanguageOptions = TRANSCRIBE_LANGUAGE_OPTIONS.replace(/\s/g, '');
@@ -812,7 +855,7 @@ const go = async function go(callData) {
       }
     }
   } else {
-    tsParams.LanguageCode = TRANSCRIBE_LANGUAGE_CODE;
+    tsParams.LanguageCode = transcribeLanguageCode;
   }
 
   if (sessionId !== undefined) {
@@ -820,18 +863,30 @@ const go = async function go(callData) {
   }
 
   if (IS_CONTENT_REDACTION_ENABLED && (
-    TRANSCRIBE_LANGUAGE_CODE === 'en-US' ||
-    TRANSCRIBE_LANGUAGE_CODE === 'en-AU' ||
-    TRANSCRIBE_LANGUAGE_CODE === 'en-GB' ||
-    TRANSCRIBE_LANGUAGE_CODE === 'es-US')) {
+    transcribeLanguageCode === 'en-US' ||
+    transcribeLanguageCode === 'en-AU' ||
+    transcribeLanguageCode === 'en-GB' ||
+    transcribeLanguageCode === 'es-US')) {
     tsParams.ContentRedactionType = CONTENT_REDACTION_TYPE;
     if (PII_ENTITY_TYPES) tsParams.PiiEntityTypes = PII_ENTITY_TYPES;
   }
-  if (CUSTOM_VOCABULARY_NAME) {
-    tsParams.VocabularyName = CUSTOM_VOCABULARY_NAME;
+  if (CUSTOM_VOCABULARY_NAMES) {
+    const vocabName = getCustomVocabName(transcribeLanguageCode);
+    if (vocabName !== null) {
+      console.log(`Using custom vocabulary ${vocabName} for language code ${transcribeLanguageCode}, (CallId: ${callId})`);
+      tsParams.VocabularyName = vocabName;
+    } else {
+      console.log(`No custom vocabulary found in [${CUSTOM_VOCABULARY_NAMES}] for language code ${transcribeLanguageCode}, (CallId: ${callId})`);
+    }
   }
-  if (CUSTOM_LANGUAGE_MODEL_NAME) {
-    tsParams.LanguageModelName = CUSTOM_LANGUAGE_MODEL_NAME;
+  if (CUSTOM_LANGUAGE_MODEL_NAMES) {
+    const langModelName = getCustomLanguageModelName(transcribeLanguageCode);
+    if (langModelName !== null) {
+      console.log(`Using custom language model ${langModelName} for language code ${transcribeLanguageCode}, (CallId: ${callId})`);
+      tsParams.LanguageModelName = langModelName;
+    } else {
+      console.log(`No custom language model found in [${CUSTOM_LANGUAGE_MODEL_NAMES}] for language code ${transcribeLanguageCode}, (CallId: ${callId})`);
+    }
   }
 
   /* start the stream - retry on exceptions */

--- a/lca-chimevc-stack/template.yaml
+++ b/lca-chimevc-stack/template.yaml
@@ -206,8 +206,12 @@ Parameters:
     Type: String
     Default: ""
     Description: >-
-      The name of the vocabulary to use when processing the transcription job. Leave blank if no
-      custom vocabulary to be used. If yes, the custom vocabulary must pre-exist in your account.
+      The name of the custom language model to use when processing the transcription job. Leave blank if no
+      custom language model is to be used. If specified, the custom language model must pre-exist in your account, 
+      match the Language Code selected above, and use the 'Narrow Band' base model.
+      Specify multiple custom language models by separating them with a comma (,) and appending language 
+      code after each language model name as '_<langcode>', e.g. 'MyCLM_en-US, MyCLM_es-US' to support using custom 
+      language models for different languages set by a custom call initialization Lambda Hook.
 
   CustomLanguageModelName:
     Type: String
@@ -216,6 +220,9 @@ Parameters:
       The name of the custom language model to use when processing the transcription job. Leave blank if no
       custom language model is to be used. If specified, the custom language model must pre-exist in your account, 
       match the Language Code selected above, and use the 'Narrow Band' base model.
+      Specify multiple custom language models by separating them with a comma (,) and appending language 
+      code after each language model name as '_<langcode>', e.g. 'MyCLM_en-US, MyCLM_es-US' to support using custom 
+      language models for different languages set by a custom call initialization Lambda Hook.
 
   PcaS3BucketName:
     Type: String

--- a/lca-main.yaml
+++ b/lca-main.yaml
@@ -352,8 +352,13 @@ Parameters:
     Type: String
     Default: ""
     Description: >-
-      The name of the vocabulary to use when processing the transcription job. Leave blank if no custom vocabulary to be used. If yes, the custom
-      vocabulary must pre-exist in your account.
+      The name of the vocabulary to use when processing the transcription job. Leave blank if no
+      custom vocabulary to be used. If yes, the custom vocabulary must pre-exist in your account.
+      Multiple values are currently supported only when CallAudioSource is either 'Demo Asterisk PBX Server' or 
+      'Amazon Chime SDK Voice Connector (SIPREC)', AND CallAudioProcessor is 'Call Transcriber Lambda'.
+      Specify multiple custom vocabularies by separating them with a comma (,) and appending language 
+      code after each vocabulary name as '_<langcode>', e.g. 'MyVocab_en-US,MyVocab_es-US' to support using custom 
+      vocabularies for different languages set by a custom call initialization Lambda Hook.
 
   CustomLanguageModelName:
     Type: String
@@ -362,6 +367,11 @@ Parameters:
       The name of the custom language model to use when processing the transcription job. Leave blank if no
       custom language model is to be used. If specified, the custom language model must pre-exist in your account, 
       match the Language Code selected above, and use the 'Narrow Band' base model.
+      Multiple values are currently supported only when CallAudioSource is either 'Demo Asterisk PBX Server' or 
+      'Amazon Chime SDK Voice Connector (SIPREC)', AND CallAudioProcessor is 'Call Transcriber Lambda'.
+      Specify multiple custom language models by separating them with a comma (,) and appending language 
+      code after each language model name as '_<langcode>', e.g. 'MyCLM_en-US, MyCLM_es-US' to support using custom 
+      language models for different languages set by a custom call initialization Lambda Hook.
 
   IsSentimentAnalysisEnabled:
     Type: String
@@ -1002,26 +1012,45 @@ Resources:
         import cfnresponse
         import json
         import boto3
+        import re
         def is_model_available(modelId):
           try:
-              client = boto3.client('bedrock-runtime')
-              prompt = "Why is the sky blue?"
-              if 'embed' in modelId:
-                  body = {"inputText": prompt}
-              else:
-                  body = {
-                      "anthropic_version": "bedrock-2023-05-31",
-                      "messages": [{"role": "user", "content": [{'type': 'text', 'text': prompt}]}],
-                      "max_tokens": 128
-                  }
-              print(f"Testing model: {modelId} - {body}")
-              client.invoke_model(body=json.dumps(
-                  body), modelId=modelId, accept='application/json', contentType='application/json')
-              print(f"The model '{modelId}' is available and enabled.")
-              return True
+            client = boto3.client('bedrock-runtime')
+            prompt = "Why is the sky blue?"
+            if 'embed' in modelId:
+              body = {"inputText": prompt}
+            else:
+              body = {
+                  "anthropic_version": "bedrock-2023-05-31",
+                  "messages": [{"role": "user", "content": [{'type': 'text', 'text': prompt}]}],
+                  "max_tokens": 128
+              }
+            print(f"Testing model: {modelId} - {body}")
+            client.invoke_model(body=json.dumps(
+                body), modelId=modelId, accept='application/json', contentType='application/json')
+            print(f"The model '{modelId}' is available and enabled.")
+            return True
           except Exception as e:
-              print(f"The model '{modelId}' is not available or not enabled. {e}")
+            print(f"The model '{modelId}' is not available or not enabled. {e}")
+            return False
+        def isCvOrClmListAllowed(nameList, callAudioSource, callAudioProcessor):
+          names = nameList.split(',')
+          if len(names) == 1:
+            return True
+          if callAudioSource in ['Demo Asterisk PBX Server', 'Amazon Chime SDK Voice Connector (SIPREC)'] and callAudioProcessor in ['Call Transcriber Lambda']:
+            return True
+          return False
+        def isValidCvOrClmName(nameList):
+          names = nameList.split(',')
+          if len(names) == 1:
+              return True
+          # Define the expected language code pattern
+          lang_code_pattern = "_[a-z]{2}-[A-Z]{2}$"
+          for name in names:
+            if not re.search(lang_code_pattern, name):
+              print(f"Error: The name '{name}' is invalid. Each name should contain a language code suffix of the form '_<langcode>'.")
               return False
+          return True
         def handler(event, context):
             print(json.dumps(event))
             status = cfnresponse.SUCCESS
@@ -1034,12 +1063,27 @@ Resources:
               transcribePreferredLanguage = event['ResourceProperties'].get('TranscribePreferredLanguage', '')
               customVocabularyName = event['ResourceProperties'].get('CustomVocabularyName', '')
               customLanguageModelName = event['ResourceProperties'].get('CustomLanguageModelName', '')
-              # Check language code and options are valid for Transcribe analytics
+              callAudioSource = event['ResourceProperties'].get('CallAudioSource', '')
+              callAudioProcessor = event['ResourceProperties'].get('CallAudioProcessor', '')
               if transcribeApiMode == 'analytics':
                 allowedTCALanguages = ['en-US', 'en-GB', 'es-US', 'fr-CA', 'fr-FR', 'en-AU',  'it-IT', 'de-DE', 'pt-BR']
                 if transcribeLanguageCode not in allowedTCALanguages:
                   status = cfnresponse.FAILED
                   reason = f"Selected Transcribe Language '{transcribeLanguageCode}' is not supported by Transcribe Call Analytics - must be one of: {allowedTCALanguages}. Please choose a supported language or set Transcribe API mode to 'standard'"
+              if customVocabularyName:
+                if not isCvOrClmListAllowed(customVocabularyName, callAudioSource, callAudioProcessor):
+                  status = cfnresponse.FAILED
+                  reason = f"CustomVocabularyName '{customVocabularyName}' is not valid for CallAudioSource '{callAudioSource}' and CallAudioProcessor '{callAudioProcessor}' . Multiple values are currently supported only when callAudioSource is either 'Demo Asterisk PBX Server' or 'Amazon Chime SDK Voice Connector (SIPREC)', AND CallAudioProcessor is 'Call Transcriber Lambda'."
+                elif not isValidCvOrClmName(customVocabularyName):
+                  status = cfnresponse.FAILED
+                  reason = f"CustomVocabularyName '{customVocabularyName}' is not valid. When a list is provided, each name in the list must have a valid language code suffix, eg 'MyName_en-US, MyName_es-US'"
+              if customLanguageModelName:
+                if isCvOrClmListAllowed(customLanguageModelName, callAudioSource, callAudioProcessor):
+                  status = cfnresponse.FAILED
+                  reason = f"CustomLanguageModelName '{customLanguageModelName}' is not valid for CallAudioSource '{callAudioSource}' and CallAudioProcessor '{callAudioProcessor}' . Multiple values are currently supported only when callAudioSource is either 'Demo Asterisk PBX Server' or 'Amazon Chime SDK Voice Connector (SIPREC)', AND CallAudioProcessor is 'Call Transcriber Lambda'."
+                elif not isValidCvOrClmName(customLanguageModelName):
+                  status = cfnresponse.FAILED
+                  reason = f"CustomLanguageModelName '{customLanguageModelName}' is not valid. When a list is provided, each name in the list must have a valid language code suffix, eg 'MyName_en-US, MyName_es-US'"
               if transcribeLanguageCode in ['identify-language', 'identify-multiple-languages']:
                 if customVocabularyName:
                   status = cfnresponse.FAILED
@@ -1105,6 +1149,8 @@ Resources:
       TranscribePreferredLanguage: !Ref TranscribePreferredLanguage
       CustomVocabularyName: !Ref CustomVocabularyName
       CustomLanguageModelName: !Ref CustomLanguageModelName
+      CallAudioSource: !Ref CallAudioSource
+      CallAudioProcessor: !Ref CallAudioProcessor
       BedrockModelIds:
         - !Ref SummaryBedrockModelId # Call summarization
         - !Ref AgentAssistLLMBedrockModelId # Agent assistant
@@ -1532,6 +1578,9 @@ Resources:
 
   VPCSTACK:
     Type: AWS::CloudFormation::Stack
+    DependsOn:
+      - IsStacknameLengthOK
+      - ValidateParameters
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-vpc-stack/template.yaml
@@ -1542,6 +1591,9 @@ Resources:
   CHIMEVCSTACK:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldInstallChimeVCStack
+    DependsOn:
+      - IsStacknameLengthOK
+      - ValidateParameters
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-chimevc-stack/template.yaml
@@ -1595,6 +1647,9 @@ Resources:
   CONNECTKVSSTACK:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldInstallConnectKVSStack
+    DependsOn:
+      - IsStacknameLengthOK
+      - ValidateParameters
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-connect-kvs-stack/template.yaml
@@ -1624,6 +1679,9 @@ Resources:
   GENESYSAUDIOHOOKTRANSCRIBERSTACK:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldInstallGenesysAudiohookStack
+    DependsOn:
+      - IsStacknameLengthOK
+      - ValidateParameters
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-genesys-audiohook-stack/<VERSION_TOKEN>/template.yaml
@@ -1661,6 +1719,9 @@ Resources:
   WEBSOCKETTRANSCRIBERSTACK:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldInstallWebSocketStack
+    DependsOn:
+      - IsStacknameLengthOK
+      - ValidateParameters
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-websocket-transcriber-stack/<VERSION_TOKEN>/template.yaml
@@ -1708,6 +1769,9 @@ Resources:
   CONNECTINTEGRATIONSTACK:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldInstallConnectIntegrationStack
+    DependsOn:
+      - IsStacknameLengthOK
+      - ValidateParameters
     Properties:
       # yamllint disable rule:line-length
       TemplateURL: https://s3.<REGION_TOKEN>.amazonaws.com/<ARTIFACT_BUCKET_TOKEN>/<ARTIFACT_PREFIX_TOKEN>/lca-connect-integration-stack/template.yaml


### PR DESCRIPTION
*Issue #, if available:*

Add ability to override default Transcribe language code using SIPREC Call initialization lambda hook #165

*Description of changes:*

- Add ability to override default Transcribe language code using SIPREC Call initialization lambda hook #165
- Add ability to specify multiple language specific CustomVocabulary or CLM and associated logic to select the appropriate one based on dynamic LanguageCode 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
