### PR TITLE
Fix for mic input role assignment issue

### DIFF
--- a/lca-ai-stack/source/ui/src/components/stream-audio/StreamAudio.jsx
+++ b/lca-ai-stack/source/ui/src/components/stream-audio/StreamAudio.jsx
@@ -199,8 +199,13 @@ const StreamAudio = () => {
       const monoMicSource = convertToMono(micAudioSource.current);
 
       channelMerger.current = audioContext.current.createChannelMerger(2);
-      monoMicSource.connect(channelMerger.current, 0, 0);
-      monoDisplaySource.connect(channelMerger.current, 0, 1);
+      if (micInputOption.value === 'agent') {
+        monoMicSource.connect(channelMerger.current, 0, 0);
+        monoDisplaySource.connect(channelMerger.current, 0, 1);
+      } else {
+        monoMicSource.connect(channelMerger.current, 0, 1);
+        monoDisplaySource.connect(channelMerger.current, 0, 0);        
+      }
 
       console.log(`
         DEBUG - [${new Date().toISOString()}]: Registering and adding AudioWorklet processor to capture audio

--- a/lca-ai-stack/source/ui/src/components/stream-audio/StreamAudio.jsx
+++ b/lca-ai-stack/source/ui/src/components/stream-audio/StreamAudio.jsx
@@ -204,7 +204,7 @@ const StreamAudio = () => {
         monoDisplaySource.connect(channelMerger.current, 0, 1);
       } else {
         monoMicSource.connect(channelMerger.current, 0, 1);
-        monoDisplaySource.connect(channelMerger.current, 0, 0);        
+        monoDisplaySource.connect(channelMerger.current, 0, 0);
       }
 
       console.log(`


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/amazon-transcribe-live-call-analytics/issues/169

*Description of changes:*
In StreamAudio.jsx, check micInputOption.value. Based on the value (agent vs. caller), setup the channel merger inputs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
