### PR TITLE
Fix/python3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved welcome email formatting and reduce risk of copy/pasting whitespace after temp password.
 - Muliple dependabot PRs
 - Improved detail in [Genesys AudioHook README](./lca-genesys-audiohook-stack/README.md) - PR #199, #188
+- Upgrade all python Lambda functions to python3.12 (latest)
 
 
 ## [0.9.2] - 2024-08-14

--- a/lca-agentassist-setup-stack/template.yaml
+++ b/lca-agentassist-setup-stack/template.yaml
@@ -146,7 +146,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 30
       InlineCode: |
         import cfnresponse
@@ -213,7 +213,7 @@ Resources:
       FunctionName: !Sub "QNA-SummarizeCall-${LCAStackName}"
       Role: !GetAtt LambdaHookSummarizeCallRole.Arn
       Handler: qna_summarize_call_function.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Environment:
         Variables:
@@ -247,7 +247,7 @@ Resources:
     Properties:
       Content: ./boto3_layer
       CompatibleRuntimes:
-        - python3.11
+        - python3.12
 
   QNABedrockKnowledgeBaseFunctionRole:
     Condition: ShouldConfigureBedrockKB
@@ -305,7 +305,7 @@ Resources:
       FunctionName: !Sub "QNA-${LCAStackName}-BedrockKB-LambdaHook"
       Role: !GetAtt QNABedrockKnowledgeBaseFunctionRole.Arn
       Handler: qna_bedrockkb_lambdahook_function.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Layers:
         - !Ref Boto3Layer
       Timeout: 900
@@ -382,7 +382,7 @@ Resources:
       FunctionName: !Sub "QNA-${LCAStackName}-BedrockLLM-LambdaHook"
       Role: !GetAtt QNABedrockLLMFunctionRole.Arn
       Handler: qna_bedrockllm_lambdahook_function.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Layers:
         - !Ref Boto3Layer
       Timeout: 900
@@ -500,7 +500,7 @@ Resources:
     Properties:
       Role: !GetAtt SetupFunctionRole.Arn
       Handler: setup_function.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Code: ./src
       LoggingConfig:

--- a/lca-ai-stack/Makefile
+++ b/lca-ai-stack/Makefile
@@ -295,6 +295,7 @@ $(PACKAGE_RELEASE_OUT_FILE): $(PACKAGE_RELEASE_REPLACE_OUT_FILE) | $(OUT_DIR)
 	@echo '[INFO] sam building template file for release $(RELEASE_VERSION)'
 	sam build \
 		--use-container \
+		--build-image public.ecr.aws/sam/build-python3.12:latest-x86_64 \
 		--parallel \
 		--cached \
 		--template-file '$(PACKAGE_RELEASE_REPLACE_OUT_FILE)' \

--- a/lca-ai-stack/deployment/lca-ai-stack.yaml
+++ b/lca-ai-stack/deployment/lca-ai-stack.yaml
@@ -737,7 +737,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt LambdaCodeBuildStartBuildExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 60
       MemorySize: 128
       Handler: lambda_start_codebuild.handler
@@ -782,7 +782,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt LambdaFetchTranscriptExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           LCA_CALL_EVENTS_TABLE: !Ref EventSourcingTable
@@ -824,7 +824,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt LLMAnthropicSummaryLambdaExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           LCA_CALL_EVENTS_TABLE: !Ref EventSourcingTable
@@ -879,7 +879,7 @@ Resources:
     Condition: ShouldEnableBedrockSummarizer
     Properties:
       Role: !GetAtt BedrockSummaryLambdaExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           BEDROCK_MODEL_ID: !Ref BedrockModelId
@@ -944,7 +944,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt AsyncAgentAssistOrchestratorExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           CALL_DATA_STREAM_NAME: !Ref CallDataStream
@@ -1011,7 +1011,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt AsyncTranscriptSummaryOrchestratorExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           TRANSCRIPT_SUMMARY_FUNCTION_ARN:
@@ -1250,7 +1250,7 @@ Resources:
               Action:
                 - lambda:InvokeFunction
               Resource: !GetAtt AsyncAgentAssistOrchestrator.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Environment:
         Variables:
@@ -1290,14 +1290,15 @@ Resources:
   TranscriptEnrichmentPythonLayer:
     Type: AWS::Serverless::LayerVersion
     Metadata:
-      BuildMethod: python3.11
+      BuildMethod: python3.12
+      BuildArchitecture: arm64
     Properties:
       Description: !Sub "Transcript Enrichment Python Layer for stack: ${AWS::StackName}"
       ContentUri: ../source/lambda_layers/transcript_enrichment_layer
       CompatibleArchitectures:
         - arm64
       CompatibleRuntimes:
-        - python3.11
+        - python3.12
       RetentionPolicy: Delete
 
   ##########################################################################
@@ -1897,7 +1898,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: "index.lambda_handler"
-      Runtime: python3.11
+      Runtime: python3.12
       MemorySize: 128
       Timeout: 60
       Role: !GetAtt BucketDeleteLambdaRole.Arn

--- a/lca-ai-stack/ml-stacks/bedrock-preview-boto3-stack.yaml
+++ b/lca-ai-stack/ml-stacks/bedrock-preview-boto3-stack.yaml
@@ -41,7 +41,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Role: !GetAtt 'BedrockBoto3ZipFunctionRole.Arn'
       Timeout: 60
       MemorySize: 512
@@ -145,7 +145,7 @@ Resources:
         S3Bucket: !GetAtt BedrockBoto3Zip.Bucket
         S3Key: !GetAtt BedrockBoto3Zip.Key
       CompatibleRuntimes:
-        - python3.11
+        - python3.12
 
 Outputs:
 

--- a/lca-ai-stack/ml-stacks/sagemaker-summary-stack.yaml
+++ b/lca-ai-stack/ml-stacks/sagemaker-summary-stack.yaml
@@ -107,7 +107,7 @@ Resources:
     Properties:
       Description: This function summarizes a string from the events object called 'inputs'
       Handler: index.lambda_handler
-      Runtime: python3.11
+      Runtime: python3.12
       Role: !GetAtt 'LambdaRole.Arn'
       Timeout: 240
       Environment:

--- a/lca-ai-stack/source/lambda_functions/async_agent_assist_orchestrator/lambda_function.py
+++ b/lca-ai-stack/source/lambda_functions/async_agent_assist_orchestrator/lambda_function.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.11
+#!/usr/bin/env python3.12
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lca-ai-stack/source/lambda_functions/async_transcript_summary_orchestrator/lambda_function.py
+++ b/lca-ai-stack/source/lambda_functions/async_transcript_summary_orchestrator/lambda_function.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.11
+#!/usr/bin/env python3.12
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/lca-ai-stack/source/lambda_functions/call_event_processor/lambda_function.py
+++ b/lca-ai-stack/source/lambda_functions/call_event_processor/lambda_function.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.11
+#!/usr/bin/env python3.12
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """ Transcription Passthrough Lambda Function
@@ -44,7 +44,8 @@ else:
     SSMClient = object
 
 APPSYNC_GRAPHQL_URL = environ["APPSYNC_GRAPHQL_URL"]
-APPSYNC_CLIENT = AppsyncAioGqlClient(url=APPSYNC_GRAPHQL_URL, fetch_schema_from_transport=True)
+APPSYNC_CLIENT = AppsyncAioGqlClient(
+    url=APPSYNC_GRAPHQL_URL, fetch_schema_from_transport=True)
 
 BOTO3_SESSION: Boto3Session = boto3.Session()
 CLIENT_CONFIG = BotoCoreConfig(
@@ -56,30 +57,37 @@ STATE_DYNAMODB_RESOURCE: DynamoDBServiceResource = BOTO3_SESSION.resource(
     "dynamodb",
     config=CLIENT_CONFIG,
 )
-STATE_DYNAMODB_TABLE: DynamoDbTable = STATE_DYNAMODB_RESOURCE.Table(STATE_DYNAMODB_TABLE_NAME)
+STATE_DYNAMODB_TABLE: DynamoDbTable = STATE_DYNAMODB_RESOURCE.Table(
+    STATE_DYNAMODB_TABLE_NAME)
 
-IS_LEX_AGENT_ASSIST_ENABLED = getenv("IS_LEX_AGENT_ASSIST_ENABLED", "true").lower() == "true"
+IS_LEX_AGENT_ASSIST_ENABLED = getenv(
+    "IS_LEX_AGENT_ASSIST_ENABLED", "true").lower() == "true"
 
-IS_LAMBDA_AGENT_ASSIST_ENABLED = getenv("IS_LAMBDA_AGENT_ASSIST_ENABLED", "true").lower() == "true"
+IS_LAMBDA_AGENT_ASSIST_ENABLED = getenv(
+    "IS_LAMBDA_AGENT_ASSIST_ENABLED", "true").lower() == "true"
 
-IS_SENTIMENT_ANALYSIS_ENABLED = getenv("IS_SENTIMENT_ANALYSIS_ENABLED", "true").lower() == "true"
+IS_SENTIMENT_ANALYSIS_ENABLED = getenv(
+    "IS_SENTIMENT_ANALYSIS_ENABLED", "true").lower() == "true"
 if IS_SENTIMENT_ANALYSIS_ENABLED:
-    COMPREHEND_CLIENT: ComprehendClient = BOTO3_SESSION.client("comprehend", config=CLIENT_CONFIG)
+    COMPREHEND_CLIENT: ComprehendClient = BOTO3_SESSION.client(
+        "comprehend", config=CLIENT_CONFIG)
 else:
     COMPREHEND_CLIENT = None
 COMPREHEND_LANGUAGE_CODE = getenv("COMPREHEND_LANGUAGE_CODE", "en")
 
-SNS_CLIENT:SNSClient = BOTO3_SESSION.client("sns", config=CLIENT_CONFIG)
-SSM_CLIENT:SSMClient = BOTO3_SESSION.client("ssm", config=CLIENT_CONFIG)
+SNS_CLIENT: SNSClient = BOTO3_SESSION.client("sns", config=CLIENT_CONFIG)
+SSM_CLIENT: SSMClient = BOTO3_SESSION.client("ssm", config=CLIENT_CONFIG)
 
 LOGGER = Logger(location="%(filename)s:%(lineno)d - %(funcName)s()")
 
 EVENT_LOOP = asyncio.get_event_loop()
 
-setting_response = SSM_CLIENT.get_parameter(Name=getenv("PARAMETER_STORE_NAME"))
+setting_response = SSM_CLIENT.get_parameter(
+    Name=getenv("PARAMETER_STORE_NAME"))
 SETTINGS = json.loads(setting_response["Parameter"]["Value"])
 if "CategoryAlertRegex" in SETTINGS:
     SETTINGS['AlertRegEx'] = re.compile(SETTINGS["CategoryAlertRegex"])
+
 
 async def process_event(event) -> Dict[str, List]:
     """Processes a Batch of Transcript Records"""
@@ -102,14 +110,17 @@ async def process_event(event) -> Dict[str, List]:
 
     return processor.results
 
+
 @LOGGER.inject_lambda_context
 def handler(event, context: LambdaContext):
     # pylint: disable=unused-argument
     """Lambda handler"""
     LOGGER.debug("lambda event", extra={"event": event})
 
-    event_processor_results = EVENT_LOOP.run_until_complete(process_event(event=event))
-    LOGGER.debug("event processor results", extra=dict(event_results=event_processor_results))
+    event_processor_results = EVENT_LOOP.run_until_complete(
+        process_event(event=event))
+    LOGGER.debug("event processor results", extra=dict(
+        event_results=event_processor_results))
 
     for error in event_processor_results.get("errors", []):
         LOGGER.error("event processor error: %s", error)
@@ -119,4 +130,4 @@ def handler(event, context: LambdaContext):
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("event processor exception")
 
-    return 
+    return

--- a/lca-ai-stack/source/lambda_layers/transcript_enrichment_layer/requirements.txt
+++ b/lca-ai-stack/source/lambda_layers/transcript_enrichment_layer/requirements.txt
@@ -1,5 +1,5 @@
 # keep in sync with local dev dependencies in requirements-dev.txt
 boto3~=1.22.12
-gql[botocore,aiohttp,requests]~=3.2.0
+gql[botocore,aiohttp,requests]~=3.5.0
 aws-lambda-powertools~=1.25.10
 phonenumbers~=8.12.51

--- a/lca-bedrockkb-stack/template.yaml
+++ b/lca-bedrockkb-stack/template.yaml
@@ -190,7 +190,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 30
       InlineCode: |
         import cfnresponse
@@ -213,7 +213,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 30
       InlineCode: |
         import cfnresponse
@@ -289,7 +289,7 @@ Resources:
     Type: AWS::Lambda::LayerVersion
     Properties:
       CompatibleRuntimes:
-        - python3.11
+        - python3.12
       Content: ./opensearchpy_layer
       Description: opensearchpy layer including requests, requests-aws4auth, and boto3-1.34.82
       LicenseInfo: Apache-2.0
@@ -376,7 +376,7 @@ Resources:
         Fn::GetAtt:
           - OSSSetupLambdaFunctionRole
           - Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 840
       Code: ./src/oss_setup
       Layers:
@@ -621,7 +621,7 @@ Resources:
     Properties:
       Handler: handler.lambda_handler
       Role: !GetAtt "WebCrawlerKBDataSourceFunctionRole.Arn"
-      Runtime: python3.11
+      Runtime: python3.12
       Layers:
         - !Ref OpenSearchPyLayer
       Timeout: 600

--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-call-analytics.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-call-analytics.yaml
@@ -348,7 +348,7 @@ Resources:
               Action: iam:PassRole
               Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:*
       Handler: index.lambda_handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 300
       InlineCode: |
         import boto3
@@ -615,7 +615,7 @@ Resources:
         AWS Lambda Function that will accept events from Amazon Chime SDK Call Analytics voice
         tone analysis, modify them for use for LCA, and save them to the LCA Kinesis Data Streams
         as a voice tone analysis
-      Runtime: python3.11
+      Runtime: python3.12
       Handler: lambda_function.lambda_handler
       Layers:
         - !Ref Boto3LayerArn

--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-siprec.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-siprec.yaml
@@ -87,7 +87,7 @@ Resources:
         - CreateVCFunctionRole
         - Arn
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 300
       Code:
         ZipFile: |

--- a/lca-chimevc-stack/cloudformation-templates/chime-vc-with-asterisk-server.yaml
+++ b/lca-chimevc-stack/cloudformation-templates/chime-vc-with-asterisk-server.yaml
@@ -489,7 +489,7 @@ Resources:
           - createChimeLambdaRole
           - Arn
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 300
 
   voiceConnectorResource:

--- a/lca-connect-integration-stack/template.yaml
+++ b/lca-connect-integration-stack/template.yaml
@@ -91,7 +91,7 @@ Resources:
     Properties:
       Role: !GetAtt LambdaRole.Arn
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Code:
         ZipFile: |
@@ -179,7 +179,7 @@ Resources:
     Properties:
       Role: !GetAtt ContactEventProcessorFunctionRole.Arn
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 20
       Description: >-
         AWS Lambda Function triggered when 'CONNECTED_TO_AGENT' event is received from Connect. 

--- a/lca-connect-kvs-stack/template.yaml
+++ b/lca-connect-kvs-stack/template.yaml
@@ -178,7 +178,7 @@ Resources:
     Properties:
       Role: !GetAtt ContactEventProcessorFunctionRole.Arn
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 20
       Description: >-
         AWS Lambda Function triggered when 'CONNECTED_TO_AGENT' event is received from Connect. 

--- a/lca-genesys-audiohook-stack/deployment/genesys-audiohook.yaml
+++ b/lca-genesys-audiohook-stack/deployment/genesys-audiohook.yaml
@@ -357,7 +357,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.lambda_handler
-      Runtime: python3.11
+      Runtime: python3.12
       MemorySize: 128
       Timeout: 60
       Role: !GetAtt EcrImagesDeleteLambdaRole.Arn
@@ -609,7 +609,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt LambdaCodeBuildStartBuildExecutionRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 60
       MemorySize: 128
       Handler: lambda_start_codebuild.handler

--- a/lca-llm-template-setup-stack/deployment/llm-template-setup.yaml
+++ b/lca-llm-template-setup-stack/deployment/llm-template-setup.yaml
@@ -57,7 +57,7 @@ Resources:
       Code: ../source/lambda_functions
       Handler: llm_prompt_upload.lambda_handler
       Role: !GetAtt LLMPromptUploadRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       MemorySize: 128
       Timeout: 60
       LoggingConfig:

--- a/lca-main.yaml
+++ b/lca-main.yaml
@@ -1037,7 +1037,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       InlineCode: |
         import cfnresponse
         import time
@@ -1091,7 +1091,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Role: !GetAtt ValidateParametersFunctionRole.Arn
       Timeout: 60
       InlineCode: |
@@ -1301,7 +1301,7 @@ Resources:
     Properties:
       Role: !GetAtt UpdateLCASettingsFunctionRole.Arn
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Timeout: 900
       Code:
         ZipFile: |
@@ -1413,7 +1413,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       InlineCode: |
         import cfnresponse
         import json

--- a/lca-websocket-transcriber-stack/deployment/lca-websocket-transcriber.yaml
+++ b/lca-websocket-transcriber-stack/deployment/lca-websocket-transcriber.yaml
@@ -826,7 +826,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.11
+      Runtime: python3.12
       Role: !GetAtt ECSCleanupLambdaRole.Arn
       Timeout: 720
       InlineCode: |

--- a/plugins/salesforce-integration/template.yaml
+++ b/plugins/salesforce-integration/template.yaml
@@ -71,7 +71,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt SalesforceLookupLambdaRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           LOGGING_LEVEL: "INFO"
@@ -90,7 +90,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Role: !GetAtt SalesforceCreateCaseLambdaRole.Arn
-      Runtime: python3.11
+      Runtime: python3.12
       Environment:
         Variables:
           LOGGING_LEVEL: "INFO"


### PR DESCRIPTION
*Issue #, if available:*
#189 

*Description of changes:*

Build hangs appear to be a recent docker reliability issue running an arm64 container from sam build, on an x86 machine.
The fix is to use an x86 docker image in sam build, using the `--build-image arg` - it appears that it works to use an x86 container to build the arm64 lambda function and lambda layer artifacts.
Fix is in the lca-ai-stack Makefile:
```
sam build \
        --use-container \
        --build-image public.ecr.aws/sam/build-python3.12:latest-x86_64 \
        --parallel \
        --cached \
        --template-file 'out/template-replaced-bobs-artifacts-us-east-1-lca-python312_0.9.2_lca-ai-stack-0.9.2.yaml'
```

The PR also updates all Lambda functions to use python3.12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
