### PR TITLE
Fix/presigned url issue

### DIFF
--- a/lca-ai-stack/source/ui/src/components/common/generate-s3-presigned-url.js
+++ b/lca-ai-stack/source/ui/src/components/common/generate-s3-presigned-url.js
@@ -43,11 +43,11 @@ const generateS3PresignedUrl = async (url, credentials) => {
       return null;
     }
 
-    // Build the correct S3 URL
+    // Build the correct S3URL
     const s3Url = `https://${bucketName}.s3.${region}.amazonaws.com/${key}`;
     logger.debug('Constructed S3 URL:', s3Url);
 
-    // Parse the S3 URL
+    // Parse the S3URL
     const s3ObjectUrl = parseUrl(s3Url);
 
     // Generate the signed URL

--- a/lca-ai-stack/source/ui/src/components/common/generate-s3-presigned-url.js
+++ b/lca-ai-stack/source/ui/src/components/common/generate-s3-presigned-url.js
@@ -7,37 +7,66 @@ import { Sha256 } from '@aws-crypto/sha256-browser';
 import { formatUrl } from '@aws-sdk/util-format-url';
 import { Logger } from 'aws-amplify';
 
-let newUrl = '';
+const logger = new Logger('generateS3PresignedUrl');
 
 const generateS3PresignedUrl = async (url, credentials) => {
-  const logger = new Logger('CallPanel');
-
-  logger.debug('URL KISH:', url);
-  // prettier-ignore
-
-  const bucketName = url.split('/')[2].split('.')[0];
-  const key = `${url.split('/')[3]}/${url.split('/')[4]}`;
-  const region = url.split('/')[2].split('.')[2];
-
-  newUrl = `https://${bucketName}.s3.${region}.amazonaws.com/${key}`;
-
-  if (url.includes('detailType')) {
-    newUrl = url;
+  if (!url) {
+    logger.error('URL is undefined or empty');
+    return null;
   }
-  logger.debug('NEW URL KISH:', newUrl);
 
-  // const s3ObjectUrl = parseUrl(`https://${bucketName}.s3.${region}.amazonaws.com/${key}`);
-  const s3ObjectUrl = parseUrl(newUrl);
+  logger.debug('Original URL:', url);
 
-  const presigner = new S3RequestPresigner({
-    credentials,
-    region,
-    sha256: Sha256, // In browsers
-  });
-  // Create a GET request from S3 url.
-  const presignedResponse = await presigner.presign(new HttpRequest(s3ObjectUrl));
-  const presignedUrl = formatUrl(presignedResponse);
-  return presignedUrl;
+  try {
+    // Parse the URL correctly
+    const parsedUrl = new URL(url);
+
+    // Extract bucket name and region
+    const hostnameParts = parsedUrl.hostname.split('.');
+    let bucketName;
+    let region;
+
+    if (hostnameParts.length >= 4 && hostnameParts[1] === 's3') {
+      // Format: bucket-name.s3.region.amazonaws.com
+      bucketName = hostnameParts[0];
+      region = hostnameParts[2];
+    } else {
+      logger.error('Invalid S3 URL format:', url);
+      return null;
+    }
+
+    // Remove the leading slash from the path
+    const key = parsedUrl.pathname.substring(1);
+
+    if (!key || key === 'connect/us-connect') {
+      logger.error('Invalid or incomplete S3 object path:', key);
+      return null;
+    }
+
+    // Build the correct S3 URL
+    const s3Url = `https://${bucketName}.s3.${region}.amazonaws.com/${key}`;
+    logger.debug('Constructed S3 URL:', s3Url);
+
+    // Parse the S3 URL
+    const s3ObjectUrl = parseUrl(s3Url);
+
+    // Generate the signed URL
+    const presigner = new S3RequestPresigner({
+      credentials,
+      region,
+      sha256: Sha256,
+    });
+
+    const presignedResponse = await presigner.presign(new HttpRequest(s3ObjectUrl));
+    const presignedUrl = formatUrl(presignedResponse);
+
+    logger.debug('Generated presigned URL (truncated):', presignedUrl.substring(0, 100) + '...');
+    return presignedUrl;
+
+  } catch (error) {
+    logger.error('Error generating presigned URL:', error);
+    return null;
+  }
 };
 
 export default generateS3PresignedUrl;


### PR DESCRIPTION
*Issue #, if available:*

The conditions regarding the RecordingURL are related to the generate-s3-presigned-url.js[4], which handles the creation of signed URLs. The code fails to parse URLs when the S3 path has more than three levels and doesn't contain a detailType. For example, URLs with the following format typical of Connect call recordings will fail to parse:
https://<bucket-name>.[s3.us-east-1.amazonaws.com/connect/](http://s3.us-east-1.amazonaws.com/connect/)<instance-alias>/CallRecordings/year/month/day/<contact-id>_<UTC-timestamp>.wav

*Description of changes:*

・Error Handling:
New code returns null in error cases instead of attempting to continue with invalid data
Added validation that stops execution if URL is undefined or empty

・URL Processing:
Removed special case handling for URLs containing "detailType" (original code had if (url.includes('detailType')) { newUrl = url; })
Changed from simple string splitting to using the URL API for more robust parsing

・Path Extraction:
Original code used fixed array indices: key = ${url.split('/')[3]}/${url.split('/')[4]}
New code extracts the full path with parsedUrl.pathname.substring(1) which handles paths of any length

・Validation Logic:
Added validation that rejects URLs with empty keys or keys equal to 'connect/us-connect'
Added validation for S3 URL format that checks hostname parts

・Logging Behavior:
Changed logger name from 'CallPanel' to 'generateS3PresignedUrl'
Added detailed logging of errors and truncated presigned URL output

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
